### PR TITLE
Test enhancement

### DIFF
--- a/tests/backend/Feature/AppTest.php
+++ b/tests/backend/Feature/AppTest.php
@@ -13,7 +13,6 @@ namespace Tests\Unit;
 use Filegator\Kernel\Request;
 use Filegator\Kernel\Response;
 use Filegator\Services\Auth\AuthInterface;
-use Filegator\Services\Session\Session;
 use Filegator\Services\Session\SessionStorageInterface;
 use Tests\TestCase;
 
@@ -55,7 +54,7 @@ class AppTest extends TestCase
 
         $config = $this->getMockConfig();
 
-        $app1 = $this->bootFreshApp($config, $request1, null, true);
+        $this->bootFreshApp($config, $request1, null, true);
         $prev_session = $request1->getSession();
 
         // another request with previous session

--- a/tests/backend/Feature/AuthTest.php
+++ b/tests/backend/Feature/AuthTest.php
@@ -21,7 +21,7 @@ class AuthTest extends TestCase
 {
     public function testSuccessfulLogin()
     {
-        $ret = $this->sendRequest('POST', '/login', [
+        $this->sendRequest('POST', '/login', [
             'username' => 'john@example.com',
             'password' => 'john123',
         ]);

--- a/tests/backend/Feature/FilesTest.php
+++ b/tests/backend/Feature/FilesTest.php
@@ -11,6 +11,7 @@
 namespace Tests\Feature;
 
 use Tests\TestCase;
+use Exception;
 
 /**
  * @internal
@@ -19,14 +20,14 @@ class FilesTest extends TestCase
 {
     protected $timestamp;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resetTempDir();
 
         $this->timestamp = time();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $this->resetTempDir();
     }
@@ -234,7 +235,7 @@ class FilesTest extends TestCase
         $username = 'john@example.com';
         $this->signIn($username, 'john123');
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->sendRequest('POST', '/renameitem', [
             'from' => 'missing.txt',
@@ -256,7 +257,7 @@ class FilesTest extends TestCase
             ],
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->sendRequest('POST', '/deleteitems', [
             'items' => $items,
@@ -351,7 +352,7 @@ class FilesTest extends TestCase
             ],
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->sendRequest('POST', '/copyitems', [
             'items' => $items,

--- a/tests/backend/Feature/UploadTest.php
+++ b/tests/backend/Feature/UploadTest.php
@@ -18,7 +18,7 @@ use Tests\TestCase;
  */
 class UploadTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resetTempDir();
 

--- a/tests/backend/TestResponse.php
+++ b/tests/backend/TestResponse.php
@@ -75,7 +75,7 @@ trait TestResponse
 
         $constraint = new ArraySubset($subset, $checkForObjectIdentity);
 
-        static::assertThat($array, $constraint, $message);
+        self::assertThat($array, $constraint, $message);
     }
 
     public function getStatusCode()

--- a/tests/backend/Unit/ArchiverTest.php
+++ b/tests/backend/Unit/ArchiverTest.php
@@ -13,6 +13,8 @@ namespace Tests\Unit;
 use Filegator\Services\Archiver\Adapters\ZipArchiver;
 use Filegator\Services\Storage\Filesystem;
 use Filegator\Services\Tmpfs\Adapters\Tmpfs;
+use League\Flysystem\Memory\MemoryAdapter;
+use League\Flysystem\Adapter\NullAdapter;
 use Tests\TestCase;
 
 /**
@@ -22,7 +24,7 @@ class ArchiverTest extends TestCase
 {
     protected $archiver;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $tmpfs = new Tmpfs();
         $tmpfs->init([
@@ -42,7 +44,7 @@ class ArchiverTest extends TestCase
         $storage->init([
             'separator' => '/',
             'adapter' => function () {
-                return new \League\Flysystem\Adapter\NullAdapter();
+                return new NullAdapter();
             },
         ]);
 
@@ -58,7 +60,7 @@ class ArchiverTest extends TestCase
         $storage->init([
             'separator' => '/',
             'adapter' => function () {
-                return new \League\Flysystem\Memory\MemoryAdapter();
+                return new MemoryAdapter();
             },
         ]);
 
@@ -80,7 +82,7 @@ class ArchiverTest extends TestCase
         $storage->init([
             'separator' => '/',
             'adapter' => function () {
-                return new \League\Flysystem\Memory\MemoryAdapter();
+                return new MemoryAdapter();
             },
         ]);
 
@@ -102,7 +104,7 @@ class ArchiverTest extends TestCase
         $storage->init([
             'separator' => '/',
             'adapter' => function () {
-                return new \League\Flysystem\Memory\MemoryAdapter();
+                return new MemoryAdapter();
             },
         ]);
 
@@ -114,7 +116,7 @@ class ArchiverTest extends TestCase
 
         $this->archiver->uncompress('/testarchive.zip', '/result', $storage);
 
-        $this->assertStringContainsString('testarchive', (json_encode($storage->getDirectoryCollection('/'))));
-        $this->assertStringContainsString('onetwo', (json_encode($storage->getDirectoryCollection('/result'))));
+        $this->assertStringContainsString('testarchive', json_encode($storage->getDirectoryCollection('/')));
+        $this->assertStringContainsString('onetwo', json_encode($storage->getDirectoryCollection('/result')));
     }
 }

--- a/tests/backend/Unit/Auth/DatabaseAuthTest.php
+++ b/tests/backend/Unit/Auth/DatabaseAuthTest.php
@@ -41,6 +41,6 @@ class DatabaseAuthTest extends AuthTest
                 [password] VARCHAR(255) NOT NULL
 
             )');
-        $ret = $this->conn->fetch('SELECT * FROM users WHERE username = ?', 'admin');
+        $this->conn->fetch('SELECT * FROM users WHERE username = ?', 'admin');
     }
 }

--- a/tests/backend/Unit/Auth/JsonAuthTest.php
+++ b/tests/backend/Unit/Auth/JsonAuthTest.php
@@ -19,7 +19,7 @@ class JsonFileTest extends AuthTest
 {
     private $mock_file = TEST_DIR.'/mockusers.json';
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         @unlink($this->mock_file);
         @unlink($this->mock_file.'.blank');

--- a/tests/backend/Unit/CollectionTest.php
+++ b/tests/backend/Unit/CollectionTest.php
@@ -15,6 +15,7 @@ use Filegator\Services\Auth\UsersCollection;
 use Filegator\Services\Storage\DirectoryCollection;
 use Filegator\Utils\Collection;
 use Tests\TestCase;
+use Exception;
 
 /**
  * @internal
@@ -27,7 +28,7 @@ class CollectionTest extends TestCase
         $mock->add('one');
         $mock->add('two');
 
-        $this->assertEquals($mock->length(), 2);
+        $this->assertEquals(2, $mock->length());
     }
 
     public function testDeleteFromCollection()
@@ -36,7 +37,7 @@ class CollectionTest extends TestCase
         $mock->add('one');
         $mock->delete('one');
 
-        $this->assertEquals($mock->length(), 0);
+        $this->assertEquals(0, $mock->length());
     }
 
     public function testSort()
@@ -46,15 +47,15 @@ class CollectionTest extends TestCase
         $mock->add(['val' => 'a']);
         $mock->add(['val' => 'c']);
 
-        $this->assertEquals($mock->all()[0]['val'], 'b');
+        $this->assertEquals('b', $mock->all()[0]['val']);
 
         $mock->sortByValue('val');
 
-        $this->assertEquals($mock->all()[0]['val'], 'a');
+        $this->assertEquals('a', $mock->all()[0]['val']);
 
         $mock->sortByValue('val', true);
 
-        $this->assertEquals($mock->all()[0]['val'], 'c');
+        $this->assertEquals('c', $mock->all()[0]['val']);
     }
 
     public function testUsersCollection()
@@ -69,7 +70,7 @@ class CollectionTest extends TestCase
         $mock->addUser($user2);
         $mock->addUser($user3);
 
-        $this->assertEquals($mock->length(), 3);
+        $this->assertEquals(3, $mock->length());
     }
 
     public function testUserSerialization()
@@ -81,7 +82,7 @@ class CollectionTest extends TestCase
 
         $json = json_encode($mock);
 
-        $this->assertEquals($json, '[{"val":"b"},{"val":"a"},{"val":"c"}]');
+        $this->assertEquals('[{"val":"b"},{"val":"a"},{"val":"c"}]', $json);
     }
 
     public function testDirectoryCollection()
@@ -95,9 +96,9 @@ class CollectionTest extends TestCase
 
         $json = json_encode($dir);
 
-        $this->assertEquals($json, '{"location":"\/sub1\/sub2","files":[{"type":"back","path":"\/sub1","name":"..","size":0,"time":1558942228},{"type":"dir","path":"\/sub1\/sub2\/sub3","name":"sub3","size":0,"time":1558942228},{"type":"file","path":"\/sub1\/sub2\/test.txt","name":"test.txt","size":30000,"time":1558942228},{"type":"file","path":"\/sub1\/sub2\/test2.txt","name":"test.txt","size":30000,"time":1558942228}]}');
+        $this->assertEquals('{"location":"\/sub1\/sub2","files":[{"type":"back","path":"\/sub1","name":"..","size":0,"time":1558942228},{"type":"dir","path":"\/sub1\/sub2\/sub3","name":"sub3","size":0,"time":1558942228},{"type":"file","path":"\/sub1\/sub2\/test.txt","name":"test.txt","size":30000,"time":1558942228},{"type":"file","path":"\/sub1\/sub2\/test2.txt","name":"test.txt","size":30000,"time":1558942228}]}', $json);
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
         $dir->addFile('badType', 'aaa', 'aa', 0, 1558942228);
     }
 
@@ -110,6 +111,6 @@ class CollectionTest extends TestCase
 
         $json = json_encode($user);
 
-        $this->assertEquals($json, '[{"role":"guest","permissions":[],"homedir":"","username":"","name":""},{"role":"guest","permissions":[],"homedir":"","username":"","name":""}]');
+        $this->assertEquals('[{"role":"guest","permissions":[],"homedir":"","username":"","name":""},{"role":"guest","permissions":[],"homedir":"","username":"","name":""}]', $json);
     }
 }

--- a/tests/backend/Unit/ConfigTest.php
+++ b/tests/backend/Unit/ConfigTest.php
@@ -34,12 +34,12 @@ class ConfigTest extends TestCase
 
         $config = new Config($sample);
 
-        $this->assertEquals($config->get(), $sample);
-        $this->assertEquals($config->get('test'), 'something');
-        $this->assertEquals($config->get('test2.deep'), 123);
-        $this->assertEquals($config->get('test3.sub.subsub'), 2);
-        $this->assertEquals($config->get('not-found'), null);
-        $this->assertEquals($config->get('not-found', 'default'), 'default');
-        $this->assertEquals($config->get('not.found', 'default'), 'default');
+        $this->assertEquals($sample, $config->get());
+        $this->assertEquals('something', $config->get('test'));
+        $this->assertEquals(123, $config->get('test2.deep'));
+        $this->assertEquals(2, $config->get('test3.sub.subsub'));
+        $this->assertNull($config->get('not-found'));
+        $this->assertEquals('default', $config->get('not-found', 'default'));
+        $this->assertEquals('default', $config->get('not.found', 'default'));
     }
 }

--- a/tests/backend/Unit/MainTest.php
+++ b/tests/backend/Unit/MainTest.php
@@ -34,8 +34,8 @@ class MainTest extends TestCase
 
         $app = new App($config, $request, $response, $sresponse, $container);
 
-        $this->assertEquals($app->resolve(Config::class), $config);
-        $this->assertEquals($app->resolve(Request::class), $request);
+        $this->assertEquals($config, $app->resolve(Config::class));
+        $this->assertEquals($request, $app->resolve(Request::class));
         $this->assertInstanceOf(Response::class, $app->resolve(Response::class));
     }
 }

--- a/tests/backend/Unit/RequestTest.php
+++ b/tests/backend/Unit/RequestTest.php
@@ -25,15 +25,15 @@ class RequestTest extends TestCase
             'GET'
         );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'r' => '/test',
             'a' => '1',
             'b' => '2',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('r'), '/test');
-        $this->assertEquals($request->input('a'), '1');
-        $this->assertEquals($request->input('b'), '2');
+        $this->assertEquals('/test', $request->input('r'));
+        $this->assertEquals('1', $request->input('a'));
+        $this->assertEquals('2', $request->input('b'));
     }
 
     public function testPostRequest()
@@ -44,13 +44,13 @@ class RequestTest extends TestCase
             ['param1' => '1', 'param2' => '2']
             );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'param1' => '1',
             'param2' => '2',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('param1'), '1');
-        $this->assertEquals($request->input('param2'), '2');
+        $this->assertEquals('1', $request->input('param1'));
+        $this->assertEquals('2', $request->input('param2'));
     }
 
     public function testJsonRequest()
@@ -65,11 +65,11 @@ class RequestTest extends TestCase
             json_encode(['sample' => 'content'])
         );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'sample' => 'content',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('sample'), 'content');
+        $this->assertEquals('content', $request->input('sample'));
     }
 
     public function testGetAndJsonParametersTogether()
@@ -84,15 +84,15 @@ class RequestTest extends TestCase
             json_encode(['sample' => 'content', 'more' => '1'])
         );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'priority' => '1',
             'sample' => 'content',
             'more' => '1',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('priority'), '1');
-        $this->assertEquals($request->input('sample'), 'content');
-        $this->assertEquals($request->input('more'), '1');
+        $this->assertEquals('1', $request->input('priority'));
+        $this->assertEquals('content', $request->input('sample'));
+        $this->assertEquals('1', $request->input('more'));
     }
 
     public function testGetPostParametersTogether()
@@ -103,15 +103,15 @@ class RequestTest extends TestCase
             ['param' => 'param1', 'priority' => 5]
             );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'priority' => '10',
             'something' => 'else',
             'param' => 'param1',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('priority'), '10');
-        $this->assertEquals($request->input('something'), 'else');
-        $this->assertEquals($request->input('param'), 'param1');
+        $this->assertEquals('10', $request->input('priority'));
+        $this->assertEquals('else', $request->input('something'));
+        $this->assertEquals('param1', $request->input('param'));
     }
 
     public function testGetPostAndJsonParametersTogether()
@@ -126,16 +126,16 @@ class RequestTest extends TestCase
             json_encode(['sample' => 'content', 'priority' => '2'])
         );
 
-        $this->assertEquals($request->all(), [
+        $this->assertEquals([
             'priority' => '10',
             'something' => 'else',
             'param' => 'param1',
             'sample' => 'content',
-        ]);
+        ], $request->all());
 
-        $this->assertEquals($request->input('priority'), '10');
-        $this->assertEquals($request->input('something'), 'else');
-        $this->assertEquals($request->input('param'), 'param1');
-        $this->assertEquals($request->input('sample'), 'content');
+        $this->assertEquals('10', $request->input('priority'));
+        $this->assertEquals('else', $request->input('something'));
+        $this->assertEquals('param1', $request->input('param'));
+        $this->assertEquals('content', $request->input('sample'));
     }
 }

--- a/tests/backend/Unit/RouterTest.php
+++ b/tests/backend/Unit/RouterTest.php
@@ -24,7 +24,7 @@ class RouterTest extends TestCase
 {
     private $config_stub;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->config_stub = [
             'query_param' => 'r',
@@ -46,7 +46,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\ViewController', 'index'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testPostToLogin()
@@ -61,7 +61,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\AuthController', 'login'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testRouteNotFound()
@@ -76,7 +76,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\ErrorController', 'notFound'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testMethodNotAllowed()
@@ -91,7 +91,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\ErrorController', 'methodNotAllowed'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testRouteIsProtectedFromGuests()
@@ -106,7 +106,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\ErrorController', 'notFound'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testRouteIsAllowedForUser()
@@ -122,7 +122,7 @@ class RouterTest extends TestCase
             ->with(['ProtectedController', 'protectedMethod'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testRouteIsProtectedFromUsers()
@@ -138,7 +138,7 @@ class RouterTest extends TestCase
             ->with(['\Filegator\Controllers\ErrorController', 'notFound'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     public function testRouteIsAllowedForAdmin()
@@ -154,7 +154,7 @@ class RouterTest extends TestCase
             ->with(['AdminController', 'adminOnlyMethod'], [])
         ;
 
-        $router = $this->getRouter($request, $user, $container);
+        $this->getRouter($request, $user, $container);
     }
 
     private function getRouter(Request $request, User $user, Container $container)

--- a/tests/backend/Unit/SessionStorageTest.php
+++ b/tests/backend/Unit/SessionStorageTest.php
@@ -21,7 +21,7 @@ class SessionStorageTest extends TestCase
 {
     protected $session_service;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->session_service = new SessionStorage(new Request());
         $this->session_service->init([
@@ -53,7 +53,7 @@ class SessionStorageTest extends TestCase
         $this->session_service->set('test2', 999);
         $this->session_service->save();
 
-        $this->assertEquals($this->session_service->get('test2'), 999);
+        $this->assertEquals(999, $this->session_service->get('test2'));
         $this->assertNull($this->session_service->get('test1'));
     }
 }

--- a/tests/backend/Unit/TmpfsTest.php
+++ b/tests/backend/Unit/TmpfsTest.php
@@ -20,7 +20,7 @@ class TmpfsTest extends TestCase
 {
     protected $service;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->resetTempDir();
         rmdir(TEST_TMP_PATH);
@@ -56,7 +56,7 @@ class TmpfsTest extends TestCase
 
         $contents = $this->service->read('a.txt');
 
-        $this->assertEquals($contents, 'lorem');
+        $this->assertEquals('lorem', $contents);
     }
 
     public function testReadingTmpFileContentsUsingStream()
@@ -67,7 +67,7 @@ class TmpfsTest extends TestCase
         $this->assertEquals($ret['filename'], 'a.txt');
 
         $contents = stream_get_contents($ret['stream']);
-        $this->assertEquals($contents, 'lorem');
+        $this->assertEquals('lorem', $contents);
     }
 
     public function testRemovingTmpFile()

--- a/tests/backend/Unit/UserTest.php
+++ b/tests/backend/Unit/UserTest.php
@@ -8,8 +8,11 @@
  * For the full copyright and license information, please view the LICENSE file
  */
 
+namespace Tests\Unit;
+
 use Filegator\Services\Auth\User;
 use Tests\TestCase;
+use Exception;
 
 /**
  * @internal
@@ -68,7 +71,7 @@ class UserTest extends TestCase
     {
         $user = new User();
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $user->setRole('nonexistent');
     }
@@ -77,7 +80,7 @@ class UserTest extends TestCase
     {
         $user = new User();
 
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $user->setPermissions(['read', 'write', 'nonexistent']);
     }


### PR DESCRIPTION
# Changed log
- According to [PHPUnit fixtures reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` and `tearDown` methods should be `protected`, not `public`.
- Remove unused variables and declared namespace.
- The `assertEquals` method should be `assertEquals($expected, $actual)`.
Changing some parameter positions to correct the assertion usage.
- The `assertThat` method can call via `$this` or `self`.
To be compatible with static method, using `self` instead, not using `static`.
- Using the `assertNull` to assert expected is same as `null`.
- To be consistency, using class namespace declaring at the head of PHP file.