### PR TITLE
add folder upload with drag&drop

### DIFF
--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -8,7 +8,7 @@
 
     <Upload v-if="can('upload')" v-show="dropZone == false" :files="files" :drop-zone="dropZone" />
 
-    <b-upload v-if="dropZone && ! isLoading" multiple drag-drop @input="files = $event">
+    <b-upload v-if="dropZone && ! isLoading" multiple drag-drop>
       <b class="drop-info">{{ lang('Drop files to upload') }}</b>
     </b-upload>
 

--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -76,7 +76,7 @@ export default {
   },
   watch: {
     'files' (files) {
-      _.forEach(files, file => {        
+      _.forEach(files, file => {
         this.resumable.addFile(file)
       })
     },
@@ -112,17 +112,15 @@ export default {
 
     this.resumable.assignDrop(document.getElementById('dropzone'))
 
-    var _parentThis = this
+    this.resumable.on('fileAdded', (file) => {
+      this.visible = true
+      this.progressVisible = true
 
-    this.resumable.on('fileAdded', function(file) {
-      _parentThis.visible = true
-      _parentThis.progressVisible = true
+      if(file.relativePath === undefined || file.relativePath === null || file.relativePath == file.fileName) file.relativePath = this.$store.state.cwd.location
+      else file.relativePath = [this.$store.state.cwd.location, file.relativePath].join('/').replace('//', '/').replace(file.fileName, '').replace(/\/$/, '')
 
-      if(file.relativePath === undefined || file.relativePath === null || file.relativePath == file.fileName) file.relativePath = _parentThis.$store.state.cwd.location
-      else file.relativePath = [_parentThis.$store.state.cwd.location, file.relativePath].join('/').replace('//', '/').replace(file.fileName, '').replace(/\/$/, '')
-
-      if (!_parentThis.paused) {
-        _parentThis.resumable.upload()
+      if (!this.paused) {
+        this.resumable.upload()
       }
 
     })

--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -110,22 +110,22 @@ export default {
       return
     }
 
-    this.resumable.assignDrop(document.getElementById('dropzone'));
+    this.resumable.assignDrop(document.getElementById('dropzone'))
 
-    var _parentThis = this;
+    var _parentThis = this
 
     this.resumable.on('fileAdded', function(file) {
-      _parentThis.visible = true;
-      _parentThis.progressVisible = true;
+      _parentThis.visible = true
+      _parentThis.progressVisible = true
 
-      if(file.relativePath === undefined || file.relativePath === null || file.relativePath == file.fileName) file.relativePath = _parentThis.$store.state.cwd.location;
-      else file.relativePath = [_parentThis.$store.state.cwd.location, file.relativePath].join('/').replace('//', '/').replace(file.fileName, '').replace(/\/$/, '');
+      if(file.relativePath === undefined || file.relativePath === null || file.relativePath == file.fileName) file.relativePath = _parentThis.$store.state.cwd.location
+      else file.relativePath = [_parentThis.$store.state.cwd.location, file.relativePath].join('/').replace('//', '/').replace(file.fileName, '').replace(/\/$/, '')
 
       if (!_parentThis.paused) {
-        _parentThis.resumable.upload();
+        _parentThis.resumable.upload()
       }
 
-    });
+    })
 
     this.resumable.on('fileSuccess', (file) => {
       file.file.uploadingError = false


### PR DESCRIPTION
I tried to upload some folders. Seems like they are handled as an empty file because Buefy-upload can't handle folders yet:
![grafik](https://user-images.githubusercontent.com/23347180/97349694-131da800-1890-11eb-8cf9-1345e1264720.png)

Found #25 in a quick search, so I tried to add this as a feature.
With some (small) changes in the frontend it seems already to work:
- Browser.vue
  - unbind Buefy-upload from 'dropzone'
- Upload.vue
  - bind resumable directly to 'dropzone'
  - changes to combine relativePaths from filegator and resumable 