### PR TITLE
potential fix for issue #17 (sorting files in Firefox)

### DIFF
--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -536,21 +536,19 @@ export default {
       return this.customSort(a, b, !order, 'time')
     },
     customSort(a, b, order, param) {
-      // TODO: firefox is broken
-      if (b.type == 'back') return 1
       if (a.type == 'back') return -1
-      if (b.type == 'dir' && a.type == 'dir') {
-        return (a[param] < b[param]) || order ? -1 : 1
-      } else if (b.type == 'dir') {
-        return 1
-      } else if (a.type == 'dir') {
-        return -1
-      }
-      if (_.isString(a[param])) {
-        return (_.lowerCase(a[param]) < _.lowerCase(b[param])) || order ? -1 : 1
-      } else {
-        return (a[param] < b[param]) || order ? -1 : 1
-      }
+      if (b.type == 'back') return 1
+      
+      if (a.type == 'dir' && b.type != 'dir') return -1
+      if (b.type == 'dir' && a.type != 'dir') return 1
+
+      if (b.type == a.type)
+      {
+        if (a[param] === b[param]) return this.customSort(a, b, false, 'name')
+
+        if (_.isString(a[param])) return (a[param].localeCompare(b[param])) * (order ? -1 : 1)
+        else return ((a[param] < b[param]) ? -1 : 1) * (order ? -1 : 1)
+      } 
     },
   }
 }


### PR DESCRIPTION
not really a js guru, just a different approach.
this way we are fixing the order: back, dirs, files
inside dirs and inside files: compare and if order is true, switch the pos with *-1