### PR TITLE
fix row height on very long file names

### DIFF
--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -586,6 +586,9 @@ export default {
 .file-row a {
   color: #373737;
 }
+.file-row a.name {
+  word-break: break-all;
+}
 .file-row.type-dir a.name {
   font-weight: bold
 }


### PR DESCRIPTION
hey there,
on very very long file names, without a classical line-break char as whitespace or "-", the rows height are messed up.
![grafik](https://user-images.githubusercontent.com/23347180/102813465-226d2d80-43c9-11eb-932e-cca34c7f2f09.png)
By setting `word-break` to `break-all` it gets better:
![grafik](https://user-images.githubusercontent.com/23347180/102813999-2188cb80-43ca-11eb-8aeb-2acf3016d1af.png)
