### PR TITLE
show filesize and remaining time on download

### DIFF
--- a/backend/Controllers/DownloadController.php
+++ b/backend/Controllers/DownloadController.php
@@ -69,6 +69,7 @@ class DownloadController
         $extension = pathinfo($file['filename'], PATHINFO_EXTENSION);
         $mimes = (new MimeTypes())->getMimeTypes($extension);
         $contentType = !empty($mimes) ? $mimes[0] : 'application/octet-stream';
+        $filesize = $file['filesize'];
 
         $disposition = HeaderUtils::DISPOSITION_ATTACHMENT;
 
@@ -91,7 +92,10 @@ class DownloadController
             'Content-Transfer-Encoding',
             'binary'
         );
-
+        $streamedResponse->headers->set(
+            'Content-Length',
+            $filesize
+        );
         // @codeCoverageIgnoreStart
         if (APP_ENV == 'development') {
             $streamedResponse->headers->set(
@@ -137,6 +141,7 @@ class DownloadController
     public function batchDownloadStart(Request $request, StreamedResponse $streamedResponse, TmpfsInterface $tmpfs)
     {
         $uniqid = (string) preg_replace('/[^0-9a-zA-Z_]/', '', (string) $request->input('uniqid'));
+        $filesize = $tmpfs->getFileSize($uniqid);
 
         $streamedResponse->setCallback(function () use ($tmpfs, $uniqid) {
             // @codeCoverageIgnoreStart
@@ -170,7 +175,10 @@ class DownloadController
             'Content-Transfer-Encoding',
             'binary'
         );
-
+        $streamedResponse->headers->set(
+            'Content-Length',
+            $filesize
+        );
         // close session so we can continue streaming, note: dev is single-threaded
         $this->session->save();
 

--- a/backend/Controllers/DownloadController.php
+++ b/backend/Controllers/DownloadController.php
@@ -141,12 +141,11 @@ class DownloadController
     public function batchDownloadStart(Request $request, StreamedResponse $streamedResponse, TmpfsInterface $tmpfs)
     {
         $uniqid = (string) preg_replace('/[^0-9a-zA-Z_]/', '', (string) $request->input('uniqid'));
-        $filesize = $tmpfs->getFileSize($uniqid);
+        $file = $tmpfs->readStream($uniqid);
 
-        $streamedResponse->setCallback(function () use ($tmpfs, $uniqid) {
+        $streamedResponse->setCallback(function () use ($file, $tmpfs, $uniqid) {
             // @codeCoverageIgnoreStart
             set_time_limit(0);
-            $file = $tmpfs->readStream($uniqid);
             if ($file['stream']) {
                 while (! feof($file['stream'])) {
                     echo fread($file['stream'], 1024 * 8);
@@ -177,7 +176,7 @@ class DownloadController
         );
         $streamedResponse->headers->set(
             'Content-Length',
-            $filesize
+            $file['filesize']
         );
         // close session so we can continue streaming, note: dev is single-threaded
         $this->session->save();

--- a/backend/Controllers/DownloadController.php
+++ b/backend/Controllers/DownloadController.php
@@ -69,7 +69,6 @@ class DownloadController
         $extension = pathinfo($file['filename'], PATHINFO_EXTENSION);
         $mimes = (new MimeTypes())->getMimeTypes($extension);
         $contentType = !empty($mimes) ? $mimes[0] : 'application/octet-stream';
-        $filesize = $file['filesize'];
 
         $disposition = HeaderUtils::DISPOSITION_ATTACHMENT;
 
@@ -92,10 +91,12 @@ class DownloadController
             'Content-Transfer-Encoding',
             'binary'
         );
-        $streamedResponse->headers->set(
-            'Content-Length',
-            $filesize
-        );
+        if (isset($file['filesize'])) {
+            $streamedResponse->headers->set(
+                'Content-Length',
+                $file['filesize']
+            );
+        }
         // @codeCoverageIgnoreStart
         if (APP_ENV == 'development') {
             $streamedResponse->headers->set(
@@ -174,10 +175,12 @@ class DownloadController
             'Content-Transfer-Encoding',
             'binary'
         );
-        $streamedResponse->headers->set(
-            'Content-Length',
-            $file['filesize']
-        );
+        if (isset($file['filesize'])) {
+            $streamedResponse->headers->set(
+                'Content-Length',
+                $file['filesize']
+            );
+        }
         // close session so we can continue streaming, note: dev is single-threaded
         $this->session->save();
 

--- a/backend/Services/Storage/Filesystem.php
+++ b/backend/Services/Storage/Filesystem.php
@@ -123,11 +123,6 @@ class Filesystem implements Service
         return $this->storage->delete($this->applyPathPrefix($path));
     }
 
-    public function getFileSize(string $path): int
-    {
-        return $this->storage->getSize($path);
-    }
-
     public function readStream(string $path): array
     {
         if ($this->isDir($path)) {
@@ -139,7 +134,7 @@ class Filesystem implements Service
         return [
             'filename' => $this->getBaseName($path),
             'stream' => $this->storage->readStream($path),
-            'filesize' => $this->getFileSize($path),
+            'filesize' => $this->storage->getSize($path),
         ];
     }
 

--- a/backend/Services/Storage/Filesystem.php
+++ b/backend/Services/Storage/Filesystem.php
@@ -123,6 +123,11 @@ class Filesystem implements Service
         return $this->storage->delete($this->applyPathPrefix($path));
     }
 
+    public function getFileSize(string $path): int
+    {
+        return $this->storage->getSize($path);
+    }
+
     public function readStream(string $path): array
     {
         if ($this->isDir($path)) {
@@ -134,6 +139,7 @@ class Filesystem implements Service
         return [
             'filename' => $this->getBaseName($path),
             'stream' => $this->storage->readStream($path),
+            'filesize' => $this->getFileSize($path),
         ];
     }
 

--- a/backend/Services/Tmpfs/Adapters/Tmpfs.php
+++ b/backend/Services/Tmpfs/Adapters/Tmpfs.php
@@ -50,13 +50,6 @@ class Tmpfs implements Service, TmpfsInterface
         return $this->getPath().$filename;
     }
 
-    public function getFileSize(string $filename): int
-    {
-        $filename = $this->sanitizeFilename($filename);
-
-        return filesize($this->getPath().$filename);
-    }
-
     public function read(string $filename): string
     {
         $filename = $this->sanitizeFilename($filename);
@@ -69,10 +62,12 @@ class Tmpfs implements Service, TmpfsInterface
         $filename = $this->sanitizeFilename($filename);
 
         $stream = fopen($this->getPath().$filename, 'r');
+        $filesize = filesize($this->getPath().$filename);
 
         return [
             'filename' => $filename,
             'stream' => $stream,
+            'filesize' => $filesize,
         ];
     }
 

--- a/backend/Services/Tmpfs/Adapters/Tmpfs.php
+++ b/backend/Services/Tmpfs/Adapters/Tmpfs.php
@@ -50,6 +50,13 @@ class Tmpfs implements Service, TmpfsInterface
         return $this->getPath().$filename;
     }
 
+    public function getFileSize(string $filename): int
+    {
+        $filename = $this->sanitizeFilename($filename);
+
+        return filesize($this->getPath().$filename);
+    }
+
     public function read(string $filename): string
     {
         $filename = $this->sanitizeFilename($filename);

--- a/backend/Services/Tmpfs/TmpfsInterface.php
+++ b/backend/Services/Tmpfs/TmpfsInterface.php
@@ -27,6 +27,4 @@ interface TmpfsInterface
     public function getFileLocation(string $filename): string;
 
     public function clean(int $older_than);
-
-    public function getFileSize(string $filename): int;
 }

--- a/backend/Services/Tmpfs/TmpfsInterface.php
+++ b/backend/Services/Tmpfs/TmpfsInterface.php
@@ -27,4 +27,6 @@ interface TmpfsInterface
     public function getFileLocation(string $filename): string;
 
     public function clean(int $older_than);
+
+    public function getFileSize(string $filename): int;
 }

--- a/tests/backend/Feature/FilesTest.php
+++ b/tests/backend/Feature/FilesTest.php
@@ -155,6 +155,7 @@ class FilesTest extends TestCase
 
         mkdir(TEST_REPOSITORY.'/john');
         touch(TEST_REPOSITORY.'/john/john.txt', $this->timestamp);
+        file_put_contents(TEST_REPOSITORY.'/john/john.txt', '123456');
         touch(TEST_REPOSITORY.'/john/image.jpg', $this->timestamp);
         touch(TEST_REPOSITORY.'/john/vector.svg', $this->timestamp);
         touch(TEST_REPOSITORY.'/john/inlinedoc.pdf', $this->timestamp);
@@ -165,6 +166,7 @@ class FilesTest extends TestCase
         $this->assertEquals($headers->get('content-disposition'), "attachment; filename=file; filename*=utf-8''john.txt");
         $this->assertEquals($headers->get('content-type'), 'text/plain');
         $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 6);
         $this->assertOk();
 
         $path_encoded = base64_encode('image.jpg');
@@ -173,6 +175,7 @@ class FilesTest extends TestCase
         $this->assertEquals($headers->get('content-disposition'), "attachment; filename=file; filename*=utf-8''image.jpg");
         $this->assertEquals($headers->get('content-type'), 'image/jpeg');
         $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 0);
         $this->assertOk();
 
         $path_encoded = base64_encode('vector.svg');
@@ -181,6 +184,7 @@ class FilesTest extends TestCase
         $this->assertEquals($headers->get('content-disposition'), "attachment; filename=file; filename*=utf-8''vector.svg");
         $this->assertEquals($headers->get('content-type'), 'image/svg+xml');
         $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 0);
         $this->assertOk();
 
         $path_encoded = base64_encode('inlinedoc.pdf');
@@ -189,6 +193,7 @@ class FilesTest extends TestCase
         $this->assertEquals($headers->get('content-disposition'), "inline; filename=file; filename*=utf-8''inlinedoc.pdf");
         $this->assertEquals($headers->get('content-type'), 'application/pdf');
         $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 0);
         $this->assertOk();
     }
 
@@ -207,6 +212,7 @@ class FilesTest extends TestCase
         $this->assertEquals($headers->get('content-disposition'), "inline; filename=file; filename*=utf-8''john.pdf");
         $this->assertEquals($headers->get('content-type'), 'application/pdf');
         $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 0);
 
         $this->assertOk();
     }
@@ -634,6 +640,14 @@ class FilesTest extends TestCase
         ]);
 
         $this->assertOk();
+
+        // test headers
+        $this->response->getContent();
+        $headers = $this->streamedResponse->headers;
+        $this->assertEquals($headers->get('content-type'), 'application/octet-stream');
+        $this->assertEquals($headers->get('content-disposition'), 'attachment; filename=archive.zip');
+        $this->assertEquals($headers->get('content-transfer-encoding'), 'binary');
+        $this->assertEquals($headers->get('content-length'), 414);
     }
 
     public function testUpdateFileContent()


### PR DESCRIPTION
while downloading a (bigger) file - depending on the browser - you can't see the files full size nor the remaining time:
![grafik](https://user-images.githubusercontent.com/23347180/106484383-dd501700-64af-11eb-89b4-b8ce0eeef572.png)

by sending the content-length as additional download header, the browser can show the size and calculate the estimated time to download:
![grafik](https://user-images.githubusercontent.com/23347180/106484502-f658c800-64af-11eb-8a66-6876ea1e1d40.png)

