### PR TITLE
add support for docker, resolves #239

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM php:7-apache-buster
+
+ENV APACHE_DOCUMENT_ROOT /var/www/filegator/
+
+RUN apt-get update > /dev/null && \
+    # Install and enable php zip extension
+    apt-get install -y wget unzip libzip-dev && \
+    docker-php-ext-install zip && \
+    docker-php-ext-enable zip && \
+    # Download and extract latest build
+    cd /var/www/ && \
+    wget https://github.com/filegator/static/raw/master/builds/filegator_latest.zip && \
+    unzip filegator_latest.zip && rm filegator_latest.zip && \
+    chown -R www-data:www-data filegator/ && \
+    chmod -R 775 filegator/ && \
+    # configure Apache
+    echo '\n\
+    <VirtualHost *:80> \n\
+       DocumentRoot /var/www/filegator/dist\n\
+    </VirtualHost>\n\
+    ' >> /etc/apache2/sites-available/filegator.conf && \
+    # configure php
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
+    # cleanup apt
+    apt-get purge -y wget unzip && \
+    apt-get autoclean -y && \
+    rm -Rf /var/lib/apt/lists/*
+    
+EXPOSE 80
+
+VOLUME /var/www/filegator/repository
+VOLUME /var/www/filegator/private
+
+WORKDIR "/var/www/filegator/"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  filegator:
+    build: .
+    image: filegator:latest
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - repository:/var/www/filegator/repository
+      - private:/var/www/filegator/private
+
+volumes:
+  repository:
+  private:


### PR DESCRIPTION
While this does not add an official filegator image to docker hub, anyone using docker could easily build their own for any architecture supported by the official php image (apache/debian buster tag) using this Dockerfile.  A local filegator container can be deployed by running `docker-compose up -d` in the docker directory