### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,7 @@ RUN apt-get update > /dev/null && \
     unzip filegator_latest.zip && rm filegator_latest.zip && \
     chown -R www-data:www-data filegator/ && \
     chmod -R 775 filegator/ && \
-    # configure Apache
-    echo '\n\
-    <VirtualHost *:80> \n\
-       DocumentRoot /var/www/filegator/dist\n\
-    </VirtualHost>\n\
-    ' >> /etc/apache2/sites-available/filegator.conf && \
+    # configure Apache to use the value of APACHE_DOCUMENT_ROOT as its default Document Root
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
     sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
     # configure php


### PR DESCRIPTION
Restores the two sed commands that I removed because I misread what they did.  They replace the default document root (/var/www/html) with the environment variable APACHE_DOCUMENT_ROOT which is set to /var/www/filegator.  No need to echo any apache config files.  This fixes my mistake from https://github.com/filegator/filegator/pull/246 per https://hub.docker.com/_/php/