### PR TITLE
fix #257 and add optional domain handling

### DIFF
--- a/backend/Services/Auth/Adapters/LDAP.php
+++ b/backend/Services/Auth/Adapters/LDAP.php
@@ -75,14 +75,15 @@ class LDAP implements Service, AuthInterface
         if(!isset($username) || empty($username)) return false;
 
         // remove (optional) domains from the username
-        if(!empty($this->ldap_userFieldMapping['username_RemoveDomains']) && is_array($this->ldap_userFieldMapping['username_RemoveDomains'])){
+        if(!empty($this->ldap_userFieldMapping['username_RemoveDomains']) && is_array($this->ldap_userFieldMapping['username_RemoveDomains'])) {
             $username = str_replace($this->ldap_userFieldMapping['username_RemoveDomains'], '', $username);
         }
 
         // add the domain to the username
-        if(!empty($this->ldap_userFieldMapping['username_AddDomain'])){
-            if(strpos($username, $this->ldap_userFieldMapping['username_AddDomain']) === false)
-            $username .= $this->ldap_userFieldMapping['username_AddDomain'];
+        if(!empty($this->ldap_userFieldMapping['username_AddDomain'])) {
+            if(strpos($username, $this->ldap_userFieldMapping['username_AddDomain']) === false) {
+                $username .= $this->ldap_userFieldMapping['username_AddDomain'];
+            }
         }
 
         $all_users = $this->getUsers();
@@ -222,7 +223,7 @@ class LDAP implements Service, AuthInterface
 
                 if(is_array($user) && !empty($user)) $users[] = $user;
             }
-            //print_r($users);
+            // print_r($users); // uncomment this line to see all available ldap-login-users
         return is_array($users) ? $users : [];
     }
 

--- a/backend/Services/Auth/Adapters/LDAP.php
+++ b/backend/Services/Auth/Adapters/LDAP.php
@@ -70,6 +70,21 @@ class LDAP implements Service, AuthInterface
 
     public function authenticate($username, $password): bool
     {
+        // prevent anonymous binding
+        if(!isset($password) || empty($password)) return false;
+        if(!isset($username) || empty($username)) return false;
+
+        // remove (optional) domains from the username
+        if(!empty($this->ldap_userFieldMapping['username_RemoveDomains']) && is_array($this->ldap_userFieldMapping['username_RemoveDomains'])){
+            $username = str_replace($this->ldap_userFieldMapping['username_RemoveDomains'], '', $username);
+        }
+
+        // add the domain to the username
+        if(!empty($this->ldap_userFieldMapping['username_AddDomain'])){
+            if(strpos($username, $this->ldap_userFieldMapping['username_AddDomain']) === false)
+            $username .= $this->ldap_userFieldMapping['username_AddDomain'];
+        }
+
         $all_users = $this->getUsers();
 
         foreach ($all_users as &$u) {
@@ -184,6 +199,11 @@ class LDAP implements Service, AuthInterface
                 $user['permissions']=$this->ldap_userFieldMapping['default_permissions'];
                 $user['userDN'] = $ldapResults[$item][$this->ldap_userFieldMapping['userDN']];
 
+                if(!empty($this->ldap_userFieldMapping['username_AddDomain'])){
+                    if(strpos($user['username'], $this->ldap_userFieldMapping['username_AddDomain']) === false)
+                    $user['username'] .= $this->ldap_userFieldMapping['username_AddDomain'];
+                }
+
                 if(is_array($this->ldap_userFieldMapping['admin_usernames']))
                 {
                     if(in_array($user['username'], $this->ldap_userFieldMapping['admin_usernames'])) $user['role'] = 'admin';
@@ -202,6 +222,7 @@ class LDAP implements Service, AuthInterface
 
                 if(is_array($user) && !empty($user)) $users[] = $user;
             }
+            //print_r($users);
         return is_array($users) ? $users : [];
     }
 

--- a/docs/configuration/auth.md
+++ b/docs/configuration/auth.md
@@ -103,6 +103,8 @@ Replace your current Auth handler in `configuration.php` file like this:
                     'ldap_attributes' => ["uid","cn","dn"],
                     'ldap_userFieldMapping'=> [
                         'username' =>'uid',
+                        'username_AddDomain' =>'@example.com',
+                        'username_RemoveDomains' =>['@department1.example.com', '@department2.example.com'],
                         'name' =>'cn',
                         'userDN' =>'dn',
                         'default_permissions' => 'read|write|upload|download|batchdownload|zip',


### PR DESCRIPTION
## Fix
- #257 should be fixed by checking username and password for non empty values

## Add
- Optional configurations for domain handling
```                   
 'ldap_userFieldMapping'=> [
...
       'username_AddDomain' =>'@example.com',
       'username_RemoveDomains' =>['@department1.example.com', '@department2.example.com'], 
...
``` 
- `username_RemoveDomains` are removed from the username, so an user can login either with 
username, username@department1.example.com or username@department2.example.com
- `username_AddDomain` is the quite the opposite. It enforces to use the configured domain and adds it on the login-username and the ldap-usernames (if missing). That's useful if you use mailaddresses as usernames and are facing user request like 'our domain is soo long, do I really have to type it too?'
