### PR TITLE
Fix: for LDAP auth when user credentials are invalid

### DIFF
--- a/frontend/mixins/shared.js
+++ b/frontend/mixins/shared.js
@@ -92,7 +92,7 @@ const funcs = {
       })
     },
     is(role) {
-      return this.$store.state.user.role == role
+      return this.$store.state?.user?.role == role
     },
     can(permissions) {
       return this.$store.getters.hasPermissions(permissions)

--- a/frontend/store.js
+++ b/frontend/store.js
@@ -24,9 +24,9 @@ export default new Vuex.Store({
   getters: {
     hasPermissions: (state) => (permissions) => {
       if (_.isArray(permissions)) {
-        return _.intersection(state.user.permissions, permissions).length == permissions.length
+        return _.intersection(state.user?.permissions, permissions).length == permissions.length
       }
-      return _.find(state.user.permissions, p => p == permissions) ? true : false
+      return _.find(state.user?.permissions, p => p == permissions) ? true : false
     }
   },
   mutations: {


### PR DESCRIPTION
When using external authentication, wrong credentials lead to exceptions as below (screenshot):
![image](https://github.com/filegator/filegator/assets/4610831/2fb0345d-2da8-42c1-a6b9-f84705d6291f)

This patch handles those errors.