### PR TITLE
Add logging of user downloads

### DIFF
--- a/backend/Services/Logger/Adapters/MonoLogger.php
+++ b/backend/Services/Logger/Adapters/MonoLogger.php
@@ -32,8 +32,8 @@ class MonoLogger implements Service, LoggerInterface
         $handler->registerFatalHandler();
     }
 
-    public function log(string $message, int $level = Logger::INFO)
+    public function log(string $message, int $level = Logger::INFO, array $context = [])
     {
-        $this->logger->log($level, $message);
+        $this->logger->log($level, $message, $context);
     }
 }

--- a/backend/Services/Logger/LoggerInterface.php
+++ b/backend/Services/Logger/LoggerInterface.php
@@ -12,5 +12,5 @@ namespace Filegator\Services\Logger;
 
 interface LoggerInterface
 {
-    public function log(string $message, int $level);
+    public function log(string $message, int $level, array $context);
 }

--- a/configuration_sample.php
+++ b/configuration_sample.php
@@ -8,6 +8,7 @@ return [
     'download_inline' => ['pdf'], // download inline in the browser, array of extensions, use * for all
     'lockout_attempts' => 5, // max failed login attempts before ip lockout
     'lockout_timeout' => 15, // ip lockout timeout in seconds
+    'log_downloads' => false, //log filenames and paths
 
     'frontend_config' => [
         'app_name' => 'FileGator',


### PR DESCRIPTION

In our environment, it is necessary to log user downloads to determine which files are actually needed. I have extended the logging here to include the "context" parameter, utilizing the Monologger by default. Furthermore, logging of user downloads can now be activated via the "log_downloads" flag in the configuration.php file.

Preview of logs:

```
[2023-11-29 13:36:22] default.INFO: User download started {"type":"file","filepath":"/.gitignore","filename":".gitignore"} []
``` 