### PR TITLE
docker: merged lines to avoid useless layers

### DIFF
--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -5,28 +5,28 @@
 ################################################
 FROM php:7-apache-buster
 
-RUN apt-get update > /dev/null
-RUN apt-get install -y git libzip-dev wget unzip
+RUN apt-get update > /dev/null && \
+    apt-get install -y git libzip-dev wget unzip && \
+    docker-php-ext-install zip && \
+    docker-php-ext-enable zip && \
+    apt-get clean && apt-get autoremove -y
 
-RUN docker-php-ext-install zip
-RUN docker-php-ext-enable zip
-
-RUN wget https://github.com/filegator/static/raw/master/builds/filegator_latest.zip
-RUN unzip filegator_latest.zip -d /var/www/
-RUN rm filegator_latest.zip
-
-RUN chown -R www-data:www-data /var/www/filegator/
 WORKDIR "/var/www/filegator/"
-RUN chmod -R g+w private/
-RUN chmod -R g+w repository/
+
+RUN wget https://github.com/filegator/static/raw/master/builds/filegator_latest.zip && \
+    unzip filegator_latest.zip -d /var/www/ && \
+    rm filegator_latest.zip && \
+    chown -R www-data:www-data /var/www/filegator/ && \
+    chmod -R g+w private/ && \
+    chmod -R g+w repository/
 
 ENV APACHE_DOCUMENT_ROOT=/var/www/filegator/dist/
 ENV APACHE_PORT=8080
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/000-default.conf
-RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/docker-php.conf
-RUN sed -ri -e 's!80!${APACHE_PORT}!g' /etc/apache2/ports.conf
-RUN sed -ri -e 's!80!${APACHE_PORT}!g' /etc/apache2/sites-available/000-default.conf
-RUN a2enmod rewrite
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/000-default.conf && \
+    sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/docker-php.conf && \
+    sed -ri -e 's!80!${APACHE_PORT}!g' /etc/apache2/ports.conf && \
+    sed -ri -e 's!80!${APACHE_PORT}!g' /etc/apache2/sites-available/000-default.conf && \
+    a2enmod rewrite
 
 EXPOSE ${APACHE_PORT}
 


### PR DESCRIPTION
Hey,
Not a game changer but always some MBs saved, each RUN creates layer which occupies space, eg. wget creates file - this is one layer which is always fetched, even this file is removed later. Doing all the cleanings in one RUN makes layers a little bit smaller

```
After modification
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
a1ff72bea407   20 minutes ago   CMD ["apache2-foreground"]                      0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   USER www-data                                   0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   VOLUME [/var/www/filegator/private]             0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   VOLUME [/var/www/filegator/repository]          0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   EXPOSE map[8080/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   RUN /bin/sh -c sed -ri -e 's!/var/www/html!$…   9.14kB    buildkit.dockerfile.v0
<missing>      20 minutes ago   ENV APACHE_PORT=8080                            0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   ENV APACHE_DOCUMENT_ROOT=/var/www/filegator/…   0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   RUN /bin/sh -c wget https://github.com/fileg…   12.7MB    buildkit.dockerfile.v0
<missing>      20 minutes ago   WORKDIR /var/www/filegator/                     0B        buildkit.dockerfile.v0
<missing>      20 minutes ago   RUN /bin/sh -c apt-get update > /dev/null &&…   57.1MB    buildkit.dockerfile.v0
```

```
Original
$ docker history 60ae5728ce0d
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
60ae5728ce0d   About a minute ago   CMD ["apache2-foreground"]                      0B        buildkit.dockerfile.v0
<missing>      About a minute ago   USER www-data                                   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   VOLUME [/var/www/filegator/private]             0B        buildkit.dockerfile.v0
<missing>      About a minute ago   VOLUME [/var/www/filegator/repository]          0B        buildkit.dockerfile.v0
<missing>      About a minute ago   EXPOSE map[8080/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c a2enmod rewrite # buildkit       0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c sed -ri -e 's!80!${APACHE_POR…   1.35kB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c sed -ri -e 's!80!${APACHE_POR…   332B      buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c sed -ri -e 's!/var/www/!${APA…   7.46kB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c sed -ri -e 's!/var/www/html!$…   1.34kB    buildkit.dockerfile.v0
<missing>      About a minute ago   ENV APACHE_PORT=8080                            0B        buildkit.dockerfile.v0
<missing>      About a minute ago   ENV APACHE_DOCUMENT_ROOT=/var/www/filegator/…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c chmod -R g+w repository/ # bu…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c chmod -R g+w private/ # build…   367B      buildkit.dockerfile.v0
<missing>      About a minute ago   WORKDIR /var/www/filegator/                     0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c chown -R www-data:www-data /v…   12.7MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c rm filegator_latest.zip # bui…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c unzip filegator_latest.zip -d…   12.7MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c wget https://github.com/fileg…   4.06MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c docker-php-ext-enable zip # b…   0B        buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c docker-php-ext-install zip # …   72.9kB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c apt-get install -y git libzip…   38.9MB    buildkit.dockerfile.v0
<missing>      About a minute ago   RUN /bin/sh -c apt-get update > /dev/null # …   18.2MB    buildkit.dockerfile.v0

```