### PR TITLE
Added a column to display chmod permissions

### DIFF
--- a/frontend/translations/arabic.js
+++ b/frontend/translations/arabic.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'صلاحيات التنزيل',
   'Guest': 'زائر',
   'Show hidden': 'إظهار المخفي',
+  'Show symbolic format': 'إظهار التنسيق الرمزي',
+  'Hide symbolic format': 'إخفاء التنسيق الرمزي',
 }
 
 export default data

--- a/frontend/translations/bulgarian.js
+++ b/frontend/translations/bulgarian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Свали',
   'Guest': 'Гост',
   'Show hidden': 'Показване на скрито',
+  'Show symbolic format': 'Показване на символичен формат',
+  'Hide symbolic format': 'Скриване на символния формат',
 }
 
 export default data

--- a/frontend/translations/chinese.js
+++ b/frontend/translations/chinese.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': '下载',
   'Guest': '游客',
   'Show hidden': '显示隐藏',
+  'Show symbolic format': '显示符号格式',
+  'Hide symbolic format': '隐藏符号格式',
 }
 
 export default data

--- a/frontend/translations/czech.js
+++ b/frontend/translations/czech.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Stahování',
   'Guest': 'Host',
   'Show hidden': 'Zobrazit skryté',
+  'Show symbolic format': 'Zobrazit symbolický formát',
+  'Hide symbolic format': 'Skrýt symbolický formát',
 }
 
 export default data

--- a/frontend/translations/dutch.js
+++ b/frontend/translations/dutch.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Toestemming om te downloaden',
   'Guest': 'Gast',
   'Show hidden': 'Verborgen weergeven',
+  'Show symbolic format': 'Toon symbolisch formaat',
+  'Hide symbolic format': 'Verberg symbolisch formaat',
 }
 
 export default data

--- a/frontend/translations/english.js
+++ b/frontend/translations/english.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Download',
   'Guest': 'Guest',
   'Show hidden': 'Show hidden',
+  'Show symbolic format': 'Show symbolic format',
+  'Hide symbolic format': 'Hide symbolic format',
 }
 
 export default data

--- a/frontend/translations/estonian.js
+++ b/frontend/translations/estonian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Lae alla',
   'Guest': 'Külaline',
   'Show hidden': 'Kuva peidetud',
+  'Show symbolic format': 'Kuva sümboolne formaat',
+  'Hide symbolic format': 'Peida sümboolne formaat',
 }
 
 export default data

--- a/frontend/translations/french.js
+++ b/frontend/translations/french.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Télécharger',
   'Guest': 'Guest',
   'Show hidden': 'Afficher masqué',
+  'Show symbolic format': 'Afficher le format symbolique',
+  'Hide symbolic format': 'Masquer le format symbolique',
 }
 
 export default data

--- a/frontend/translations/galician.js
+++ b/frontend/translations/galician.js
@@ -72,6 +72,8 @@ const data = {
   'Your file is ready': 'O teu arquivo está listo',
   'View': 'Ver',
   'Show hidden': 'Amosar oculto',
+  'Show symbolic format': 'Mostrar formato simbólico',
+  'Hide symbolic format': 'Ocultar formato simbólico',
 }
 
 export default data

--- a/frontend/translations/german.js
+++ b/frontend/translations/german.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Herunterladen',
   'Guest': 'Gast',
   'Show hidden': 'Verborgenes zeigen',
+  'Show symbolic format': 'Symbolisches Format anzeigen',
+  'Hide symbolic format': 'Symbolisches Format ausblenden',
 }
 
 export default data

--- a/frontend/translations/hebrew.js
+++ b/frontend/translations/hebrew.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'הורדה',
   'Guest': 'אורח/ת',
   'Show hidden': 'הצגת קבצים מוסתרים',
+  'Show symbolic format': 'הצג פורמט סמלי',
+  'Hide symbolic format': 'הסתר פורמט סמלי',
 }
 
 export default data

--- a/frontend/translations/hungarian.js
+++ b/frontend/translations/hungarian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Letöltés engedélyezés',
   'Guest': 'Vendég',
   'Show hidden': 'Rejtett megjelenítése',
+  'Show symbolic format': 'Szimbólum formátum megjelenítése',
+  'Hide symbolic format': 'Szimbólum formátum elrejtése',
 }
 
 export default data

--- a/frontend/translations/indonesian.js
+++ b/frontend/translations/indonesian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Unduh',
   'Guest': 'Tamu',
   'Show hidden': 'Tampilkan berkas tersembunyi',
+  'Show symbolic format': 'Tampilkan format simbolik',
+  'Hide symbolic format': 'Sembunyikan format simbolik',
 }
 
 export default data

--- a/frontend/translations/italian.js
+++ b/frontend/translations/italian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Scarica',
   'Guest': 'Guest',
   'Show hidden': 'Mostra nascosto',
+  'Show symbolic format': 'Mostra formato simbolico',
+  'Hide symbolic format': 'Nascondi formato simbolico',
 }
 
 export default data

--- a/frontend/translations/japanese.js
+++ b/frontend/translations/japanese.js
@@ -71,6 +71,8 @@ const data = {
   'Deleted': '削除しました。',
   'Your file is ready': 'ファイルの準備ができました。',
   'View': '表示',
+  'Show symbolic format': 'シンボリック形式を表示',
+  'Hide symbolic format': 'シンボリック形式を非表示',
 }
 
 export default data

--- a/frontend/translations/korean.js
+++ b/frontend/translations/korean.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': '다운로드',
   'Guest': '방문자',
   'Show hidden': '숨김 표시',
+  'Show symbolic format': '기호 형식 표시',
+  'Hide symbolic format': '기호 형식 숨기기',
 }
 
 export default data

--- a/frontend/translations/lithuanian.js
+++ b/frontend/translations/lithuanian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Atsiųsti',
   'Guest': 'Guest',
   'Show hidden': 'Rodyti paslėptą',
+  'Show symbolic format': 'Rodyti simbolinį formatą',
+  'Hide symbolic format': 'Slėpti simbolinį formatą',
 }
 
 export default data

--- a/frontend/translations/persian.js
+++ b/frontend/translations/persian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'دانلود',
   'Guest': 'مهمان',
   'Show hidden': 'نمایش مخفی ها',
+  'Show symbolic format': 'نمایش قالب نمادین',
+  'Hide symbolic format': 'پنهان کردن قالب نمادین',
 }
 
 export default data

--- a/frontend/translations/polish.js
+++ b/frontend/translations/polish.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Download',
   'Guest': 'Gość',
   'Show hidden': 'Pokaż ukryte',
+  'Show symbolic format': 'Pokaż format symboliczny',
+  'Hide symbolic format': 'Ukryj format symboliczny',
 }
 
 export default data

--- a/frontend/translations/portuguese.js
+++ b/frontend/translations/portuguese.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Download',
   'Guest': 'Convidado',
   'Show hidden': 'Mostrar ocultos',
+  'Show symbolic format': 'Mostrar formato simbólico',
+  'Hide symbolic format': 'Ocultar formato simbólico',
 }
 
 export default data

--- a/frontend/translations/portuguese_br.js
+++ b/frontend/translations/portuguese_br.js
@@ -74,7 +74,9 @@ const data = {
   'Search': 'Pesquisar',
   'Download permission': 'Transferir',
   'Guest': 'Convidado',
-  'Show hidden': 'Mostrar ocultos'
+  'Show hidden': 'Mostrar ocultos',
+  'Show symbolic format': 'Mostrar formato simbólico',
+  'Hide symbolic format': 'Ocultar formato simbólico',
 }
 
 export default data

--- a/frontend/translations/romanian.js
+++ b/frontend/translations/romanian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Descărcare',
   'Guest': 'Oaspete',
   'Show hidden': 'Arată ascunse',
+  'Show symbolic format': 'Afișează formatul simbolic',
+  'Hide symbolic format': 'Ascunde formatul simbolic',
 }
 
 export default data

--- a/frontend/translations/russian.js
+++ b/frontend/translations/russian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Скачивание',
   'Guest': 'Гость',
   'Show hidden': 'Показать скрытое',
+  'Show symbolic format': 'Показать символический формат',
+  'Hide symbolic format': 'Скрыть символический формат',
 }
 
 export default data

--- a/frontend/translations/serbian.js
+++ b/frontend/translations/serbian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Preuzimanje',
   'Guest': 'Gost',
   'Show hidden': 'Prikaži skriveno',
+  'Show symbolic format': 'Prikaži simbolički format',
+  'Hide symbolic format': 'Sakrij simbolički format',
 }
 
 export default data

--- a/frontend/translations/slovak.js
+++ b/frontend/translations/slovak.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Sťahovanie',
   'Guest': 'Hosť',
   'Show hidden': 'Zobraziť skryté',
+  'Show symbolic format': 'Zobraziť symbolický formát',
+  'Hide symbolic format': 'Skryť symbolický formát',
 }
 
 export default data

--- a/frontend/translations/slovenian.js
+++ b/frontend/translations/slovenian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Prenos',
   'Guest': 'Gost',
   'Show hidden': 'Prikaži skrito',
+  'Show symbolic format': 'Prikaži simbolični format',
+  'Hide symbolic format': 'Skrij simbolični format',
 }
 
 export default data

--- a/frontend/translations/spanish.js
+++ b/frontend/translations/spanish.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Descargar',
   'Guest': 'Guest',
   'Show hidden': 'Mostrar oculto',
+  'Show symbolic format': 'Mostrar formato simbólico',
+  'Hide symbolic format': 'Ocultar formato simbólico',
 }
 
 export default data

--- a/frontend/translations/swedish.js
+++ b/frontend/translations/swedish.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Ladda ned',
   'Guest': 'Gäst',
   'Show hidden': 'Visa dold',
+  'Show symbolic format': 'Visa symboliskt format',
+  'Hide symbolic format': 'Dölj symboliskt format',
 }
 
 export default data

--- a/frontend/translations/tajik.js
+++ b/frontend/translations/tajik.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Зеркашии иҷозатҳо',
   'Guest': 'Меҳмон',
   'Show hidden': 'Пинҳонро нишон додан',
+  'Show symbolic format': 'Намоиши формати рамзӣ',
+  'Hide symbolic format': 'Пинҳон кардани формати рамзӣ',
 }
 
 export default data

--- a/frontend/translations/turkish.js
+++ b/frontend/translations/turkish.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'İndir',
   'Guest': 'Misafir',
   'Show hidden': 'Gizlenenleri göster',
+  'Show symbolic format': 'Sembolik biçimi göster',
+  'Hide symbolic format': 'Sembolik biçimi gizle',
 }
 
 export default data

--- a/frontend/translations/ukrainian.js
+++ b/frontend/translations/ukrainian.js
@@ -75,6 +75,8 @@ const data = {
   'Download permission': 'Завантаження',
   'Guest': 'Гість',
   'Show hidden': 'Показати приховане',
+  'Show symbolic format': 'Показати символічний формат',
+  'Hide symbolic format': 'Приховати символічний формат',
 }
 
 export default data

--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -100,6 +100,10 @@
               </a>
             </b-table-column>
 
+            <b-table-column :label="lang('Permissions')" field="data.permissions" sortable width="150">
+              {{ props.row.permissions !== -1 ? props.row.permissions + ' [' + convertToSymbolic(props.row.permissions, props.row.type) + ']' : lang('N/A') }}
+            </b-table-column>
+
             <b-table-column :label="lang('Size')" :custom-sort="sortBySize" field="data.size" sortable numeric width="150">
               {{ props.row.type == 'back' || props.row.type == 'dir' ? lang('Folder') : formatBytes(props.row.size) }}
             </b-table-column>
@@ -250,6 +254,15 @@ export default {
       this.showAllEntries = !this.showAllEntries
       this.loadFiles()
       this.checked = []
+    },
+    convertToSymbolic(permissions, type) {
+      if (permissions === -1) return ''
+        const symbols = ['---', '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx']
+        const owner = symbols[Math.floor(permissions / 100) % 10]
+        const group = symbols[Math.floor(permissions / 10) % 10]
+        const others = symbols[permissions % 10]
+        const prefix = type === 'dir' ? 'd' : '-'
+      return `${prefix}${owner}${group}${others}`
     },
     filterEntries(files){
       var filter_entries = this.$store.state.config.filter_entries

--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -100,7 +100,7 @@
               </a>
             </b-table-column>
 
-            <b-table-column :label="lang('Permissions')" field="data.permissions" sortable width="150">
+            <b-table-column v-if="can(['write', 'chmod'])" :label="lang('Permissions')" field="data.permissions" sortable width="150">
               {{ props.row.permissions !== -1 ? props.row.permissions + ' [' + convertToSymbolic(props.row.permissions, props.row.type) + ']' : lang('N/A') }}
             </b-table-column>
 

--- a/frontend/views/Browser.vue
+++ b/frontend/views/Browser.vue
@@ -100,8 +100,10 @@
               </a>
             </b-table-column>
 
-            <b-table-column v-if="can(['write', 'chmod'])" :label="lang('Permissions')" field="data.permissions" sortable width="150">
-              {{ props.row.permissions !== -1 ? props.row.permissions + ' [' + convertToSymbolic(props.row.permissions, props.row.type) + ']' : lang('N/A') }}
+            <b-table-column v-if="can(['write', 'chmod'])" :label="lang('Permissions')" field="data.permissions" sortable width="170">
+            <span @click="togglePermissionsView" :title="showSymbolic ? lang('Hide symbolic format') : lang('Show symbolic format')" style="font-family: monospace;cursor: pointer;">
+              {{ formatPermissions(props.row.permissions, props.row.type) }}
+            </span>
             </b-table-column>
 
             <b-table-column :label="lang('Size')" :custom-sort="sortBySize" field="data.size" sortable numeric width="150">
@@ -197,6 +199,7 @@ export default {
       files: [],
       hasFilteredEntries: false,
       showAllEntries: false,
+      showSymbolic: false,
     }
   },
   computed: {
@@ -255,6 +258,18 @@ export default {
       this.loadFiles()
       this.checked = []
     },
+    togglePermissionsView() {
+    this.showSymbolic = !this.showSymbolic
+  },
+  formatPermissions(permissions, type) {
+    if (permissions === -1) return this.lang('N/A')
+    const numeric = permissions.toString()
+    if (this.showSymbolic) {
+      const symbolic = this.convertToSymbolic(permissions, type)
+      return `${numeric} [${symbolic}]`
+    }
+    return numeric
+  },
     convertToSymbolic(permissions, type) {
       if (permissions === -1) return ''
         const symbols = ['---', '--x', '-w-', '-wx', 'r--', 'r-x', 'rw-', 'rwx']


### PR DESCRIPTION
This change introduces a new column in the FileGator interface to display file and directory permissions in both numeric (755) and symbolic (rwxr-xr-x) formats. The enhancement aims to provide a clearer and more accessible overview of permissions without requiring users to select each file or directory to view its permissions options.


- The column will be displayed only if chmod is present
- Displays symbolic format when clicked.
- Simplifies permission management by allowing users to view permissions at a glance.
- Eliminates the need for additional steps to check permissions, saving time and effort.
- Improves user experience by offering more comprehensive and direct information about files in the list.
- The functionality is fully compatible with existing FileGator features and does not affect performance.
- Provides better permission management, especially for advanced users and administrators.

![symbolic_format](https://github.com/user-attachments/assets/bfbee6ac-71b8-4fe2-b00c-f28aa7356d5a)

