### PR TITLE
Fix lazy loading images all being loaded when opening gallery

### DIFF
--- a/frontend/assets/scss/custom.scss
+++ b/frontend/assets/scss/custom.scss
@@ -36,6 +36,11 @@ html, body, #wrapper, #inner, .container {
 	justify-content: flex-end;
 }
 
+.image-lazy {
+	min-height: 200px;
+	object-fit: cover;
+}
+
 @media all and (max-width: 1088px) {
 	.container {
 		padding: 20px;

--- a/frontend/assets/scss/custom.scss
+++ b/frontend/assets/scss/custom.scss
@@ -37,7 +37,7 @@ html, body, #wrapper, #inner, .container {
 }
 
 .image-lazy {
-	min-height: 200px;
+	min-height: 150px;
 	object-fit: cover;
 }
 

--- a/frontend/views/partials/Gallery.vue
+++ b/frontend/views/partials/Gallery.vue
@@ -10,7 +10,7 @@
           <div v-if="images.length > 1" class="column is-one-fifth sidebox">
             <ul>
               <li v-for="(image, index) in images" :key="index">
-                <img v-lazy="imageSrc(image.path)" @click="currentItem = image">
+                <img v-lazy="imageSrc(image.path)" @click="currentItem = image" class="image-lazy">
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Because the lazy loaded image didn't have a limited height. Many images would load anyway because they all fit in the parent box. Giving them a minimal height with object-cover keeps them looking good while limiting the amount that is being lazy loaded at once.