### PR TITLE
Remove requirement to have /private/logs/ writable

### DIFF
--- a/configuration_sample.php
+++ b/configuration_sample.php
@@ -32,8 +32,14 @@ return [
             'config' => [
                 'monolog_handlers' => [
                     function () {
+                        $log_path = ISPC_ROOT_PATH .'/temp/';
+                        if (! is_writable($log_path)) {
+                            echo 'Folder not writable: ' . $log_path . PHP_EOL;
+                            die;
+                        }
+
                         return new \Monolog\Handler\StreamHandler(
-                            __DIR__.'/private/logs/app.log',
+                            $log_path .'filegator-app.log',
                             \Monolog\Logger::DEBUG
                         );
                     },

--- a/dist/index.php
+++ b/dist/index.php
@@ -16,11 +16,6 @@ if (version_compare(PHP_VERSION, '7.2.5', '<')) {
     die;
 }
 
-if (! is_writable(__DIR__.'/../private/logs/')) {
-    echo 'Folder not writable: /private/logs/'."\n";
-    die;
-}
-
 if (! file_exists(__DIR__.'/../configuration.php')) {
     copy(__DIR__.'/../configuration_sample.php', __DIR__.'/../configuration.php');
 }


### PR DESCRIPTION
Hi,

I'm looking to [integrate Filegator](https://git.ispconfig.org/ispconfig/ispconfig3/-/issues/1520#note_110138) with [ISPconfig](https://www.ispconfig.org/) as an extra way to manage content on sites being hosted. Leveraging an sftp adapter to flysystem.

For this I would like to refrain from creating a separate log directory ... so the current hardcoded check in dist/index.php was 'in they way' ... 
Would moving it to configuration.php be an acceptable option?
