### PR TITLE
Update file list after editing, to get new size and date/time

### DIFF
--- a/frontend/views/partials/Editor.vue
+++ b/frontend/views/partials/Editor.vue
@@ -63,6 +63,7 @@ export default {
             type: 'is-success',
           })
           this.$parent.close()
+          this.$parent.$parent.loadFiles()
         })
         .catch(error => this.handleError(error))
     }


### PR DESCRIPTION
Hi,

I noticed that after I edit a file the filesize and modification date are not updated. 
I looked at other actions that do cause the index to be reloaded and replicated the `loadFiles()` call.