### PR TITLE
Added upload speed metric to the bottom pane

### DIFF
--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -241,8 +241,8 @@ export default {
         isComplete,
         isError,
         speedBytesPerSecond: 0,
-        lastUploadedBytes: 0,
-        lastProgressAt: null,
+        speedStartBytes: 0,
+        speedStartAt: null,
         createdAt: Date.now() + this.nextUploadEntryId,
       }
 
@@ -276,8 +276,8 @@ export default {
       const bytesUploaded = this.currentUploadedBytes(entry)
 
       entry.speedBytesPerSecond = 0
-      entry.lastUploadedBytes = bytesUploaded
-      entry.lastProgressAt = Date.now()
+      entry.speedStartBytes = bytesUploaded
+      entry.speedStartAt = Date.now()
     },
     refreshEntrySpeed(entry) {
       if (!entry) return
@@ -285,28 +285,23 @@ export default {
       const now = Date.now()
       const bytesUploaded = this.currentUploadedBytes(entry)
 
-      if (!entry.lastProgressAt) {
+      if (!entry.speedStartAt) {
         this.resetEntrySpeed(entry)
         return
       }
 
-      const elapsedMs = now - entry.lastProgressAt
-      const deltaBytes = Math.max(0, bytesUploaded - entry.lastUploadedBytes)
-
-      let speedBytesPerSecond = entry.speedBytesPerSecond
-      if (elapsedMs > 0) {
-        const currentSpeed = deltaBytes / (elapsedMs / 1000)
-        speedBytesPerSecond = speedBytesPerSecond > 0
-          ? speedBytesPerSecond * 0.7 + currentSpeed * 0.3
-          : currentSpeed
+      const elapsedMs = now - entry.speedStartAt
+      if (elapsedMs <= 0) {
+        entry.speedBytesPerSecond = 0
+        return
       }
 
-      entry.speedBytesPerSecond = speedBytesPerSecond
-      entry.lastUploadedBytes = bytesUploaded
-      entry.lastProgressAt = now
+      const deltaBytes = Math.max(0, bytesUploaded - entry.speedStartBytes)
+      entry.speedBytesPerSecond = deltaBytes / (elapsedMs / 1000)
     },
     formatSpeed(bytesPerSecond) {
-      return this.formatBytes(bytesPerSecond || 0) + '/s'
+      const decimals = bytesPerSecond >= 1024 * 1024 ? 1 : 0
+      return this.formatBytes(bytesPerSecond || 0, decimals) + '/s'
     },
     entryProgressClass(entry) {
       if (entry.isError) return 'is-danger'
@@ -320,7 +315,7 @@ export default {
       return entry.inProgress && entry.resumableFile
     },
     showEntrySpeed(entry) {
-      return entry.inProgress && entry.resumableFile
+      return entry.inProgress && entry.resumableFile && entry.speedBytesPerSecond > 0
     },
     showRemove(entry) {
       return entry.isError && !entry.retryable

--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -11,6 +11,9 @@
               <span v-if="activeUploads">
                 {{ lang('Uploading files', resumable.getSize() > 0 ? Math.round(resumable.progress()*100) : 100, formatBytes(resumable.getSize())) }}
               </span>
+              <span v-if="activeUploads" class="summary-text">
+                ({{ formatSpeed(totalUploadSpeedBytes) }})
+              </span>
               <span v-if="activeUploads && paused">
                 ({{ lang('Paused') }})
               </span>
@@ -36,6 +39,12 @@
           <div v-for="entry in sortedUploadEntries" :key="entry.id">
             <div>
               <div>{{ entry.relativePath != '/' ? entry.relativePath : '' }}/{{ entry.fileName }}</div>
+              <div class="entry-meta">
+                {{ formatBytes(entry.size) }}
+                <span v-if="showEntrySpeed(entry)">
+                  , {{ formatSpeed(entry.speedBytesPerSecond) }}
+                </span>
+              </div>
               <div class="is-flex is-justify-between">
                 <progress :class="[entryProgressClass(entry), 'progress is-large']" :value="entryProgress(entry)" max="100" />
                 <a v-if="showRetry(entry)" class="progress-icon" @click="retryEntry(entry)">
@@ -92,6 +101,9 @@ export default {
     },
     failedUploadsCount() {
       return _.filter(this.uploadEntries, entry => entry.isError).length
+    },
+    totalUploadSpeedBytes() {
+      return _.sumBy(this.uploadEntries, entry => entry.inProgress ? entry.speedBytesPerSecond : 0)
     },
     sortedUploadEntries() {
       return _.orderBy(this.uploadEntries, [
@@ -168,6 +180,7 @@ export default {
         isComplete: false,
         isError: false,
       })
+      this.resetEntrySpeed(entry)
       file.file.uploadEntryId = entry.id
 
       if (!this.paused) {
@@ -200,6 +213,7 @@ export default {
       file.file.uploadingError = true
       this.progressVisible = true
       this.updateEntry(file, {
+        speedBytesPerSecond: 0,
         inProgress: false,
         isComplete: true,
         isError: true,
@@ -207,6 +221,7 @@ export default {
       this.$forceUpdate()
     })
     this.resumable.on('fileProgress', (file) => {
+      this.refreshEntrySpeed(this.findEntry(file))
       this.updateEntry(file, {
         inProgress: true,
       })
@@ -225,6 +240,9 @@ export default {
         inProgress,
         isComplete,
         isError,
+        speedBytesPerSecond: 0,
+        lastUploadedBytes: 0,
+        lastProgressAt: null,
         createdAt: Date.now() + this.nextUploadEntryId,
       }
 
@@ -247,6 +265,49 @@ export default {
 
       return entry.resumableFile.progress() * 100
     },
+    currentUploadedBytes(entry) {
+      if (!entry || !entry.resumableFile || entry.size <= 0) return 0
+
+      return Math.min(entry.size, Math.max(0, entry.resumableFile.progress() * entry.size))
+    },
+    resetEntrySpeed(entry) {
+      if (!entry) return
+
+      const bytesUploaded = this.currentUploadedBytes(entry)
+
+      entry.speedBytesPerSecond = 0
+      entry.lastUploadedBytes = bytesUploaded
+      entry.lastProgressAt = Date.now()
+    },
+    refreshEntrySpeed(entry) {
+      if (!entry) return
+
+      const now = Date.now()
+      const bytesUploaded = this.currentUploadedBytes(entry)
+
+      if (!entry.lastProgressAt) {
+        this.resetEntrySpeed(entry)
+        return
+      }
+
+      const elapsedMs = now - entry.lastProgressAt
+      const deltaBytes = Math.max(0, bytesUploaded - entry.lastUploadedBytes)
+
+      let speedBytesPerSecond = entry.speedBytesPerSecond
+      if (elapsedMs > 0) {
+        const currentSpeed = deltaBytes / (elapsedMs / 1000)
+        speedBytesPerSecond = speedBytesPerSecond > 0
+          ? speedBytesPerSecond * 0.7 + currentSpeed * 0.3
+          : currentSpeed
+      }
+
+      entry.speedBytesPerSecond = speedBytesPerSecond
+      entry.lastUploadedBytes = bytesUploaded
+      entry.lastProgressAt = now
+    },
+    formatSpeed(bytesPerSecond) {
+      return this.formatBytes(bytesPerSecond || 0) + '/s'
+    },
     entryProgressClass(entry) {
       if (entry.isError) return 'is-danger'
       if (entry.isComplete) return 'is-success'
@@ -256,6 +317,9 @@ export default {
       return entry.retryable && entry.isError
     },
     showCancel(entry) {
+      return entry.inProgress && entry.resumableFile
+    },
+    showEntrySpeed(entry) {
       return entry.inProgress && entry.resumableFile
     },
     showRemove(entry) {
@@ -268,6 +332,7 @@ export default {
       entry.isComplete = false
       entry.inProgress = true
       entry.resumableFile.file.uploadingError = false
+      this.resetEntrySpeed(entry)
       entry.resumableFile.retry()
 
       if (!this.paused) {
@@ -309,10 +374,20 @@ export default {
     },
     togglePause() {
       if (this.paused) {
+        _.forEach(this.uploadEntries, entry => {
+          if (entry.inProgress) {
+            this.resetEntrySpeed(entry)
+          }
+        })
         this.resumable.upload()
         this.paused = false
       } else {
         this.resumable.pause()
+        _.forEach(this.uploadEntries, entry => {
+          if (entry.inProgress) {
+            this.resetEntrySpeed(entry)
+          }
+        })
         this.paused = true
       }
     },
@@ -326,6 +401,11 @@ export default {
 }
 .summary-text {
   margin-left: 6px;
+}
+.entry-meta {
+  color: #6b7280;
+  font-size: 0.9rem;
+  margin-bottom: 6px;
 }
 .progress-box {
   position: fixed;


### PR DESCRIPTION
This PR adds live upload speed metric for file uploads in the bottom pane. Now we have:

- Aggregate upload speed for active uploads in the bottom pane header
- Per-file upload speed while each file is in progress

Upload speed is derived from `refreshEntrySpeed()` method and existing `Resumable.js` progress events. This method compares the current uploaded byte count against the last sampled byte count and divides it by elapsed time to get `bytes/sec`. 

## Screen Recording

[Screencast_20260417_031319.webm](https://github.com/user-attachments/assets/0b190548-f343-4ac6-9e36-0d1b529e866b)

This PR closes #573  