### PR TITLE
Fix unreadable .box text in dark theme (dark-on-dark, ~1.4:1 contrast)

### DIFF
--- a/frontend/assets/scss/theme/dark.scss
+++ b/frontend/assets/scss/theme/dark.scss
@@ -20,6 +20,7 @@
 		background-color: var(--color-surface-a0);
 	}
 
+	.box,
 	.navbar-item,
 	.label,
 	.table,


### PR DESCRIPTION
### Problem

In the dark theme, `.box` renders dark text on a dark background, making its content nearly unreadable.

`frontend/assets/scss/theme/dark.scss` sets the `.box` **background** to `--color-surface-a10` (#282828) but does **not** include `.box` in the selector group that applies `color: var(--color-text)` (#fff). So `.box` content falls back to Bulma's default text color `#4a4a4a` — dark text on a dark surface.

**Measured contrast:** computed `color: rgb(74,74,74)` on `background: rgb(40,40,40)` ≈ **1.4:1**, far below WCAG AA (4.5:1). After the fix, `#fff` on `#282828` is ≈ **14.7:1**.

Most visible in the **upload progress popup** (`.progress-box > .box` in `frontend/views/partials/Upload.vue`) and the **login box** (`frontend/views/Login.vue`).

### Fix

Add `.box` to the existing text-color selector group in `dark.scss` (the same group that already handles `.table`, modal bodies, etc.), so every `.box` surface inherits the theme text color. This mirrors the existing rule that already lists `.box` for `background-color`, and fixes `.box` globally (upload popup, login, and any other `.box` surfaces).

### How this was found

Surfaced via HestiaCP's bundled FileGator — the file manager's upload popup was unreadable in dark mode. Downstream report: hestiacp/hestiacp#5095 (fix with before/after screenshots and computed-style measurements from a live install: hestiacp/hestiacp#5497). This PR fixes it at the source for all FileGator users rather than via a downstream override.

### Verification

- Compiled the theme with `sass` (the repo's SCSS compiler): no errors, and the emitted rule now includes `.box` in the `color: var(--color-text)` group.
- Source-only change — compiled CSS is gitignored, matching prior dark.scss PRs #528/#529.
