### PR TITLE
Open the folder itself when selecting a folder search result

### DIFF
--- a/frontend/views/partials/Search.vue
+++ b/frontend/views/partials/Search.vue
@@ -85,7 +85,9 @@ export default {
             if (item.name.toLowerCase().indexOf(this.term.toLowerCase()) > -1) {
               this.results.push({
                 file: item,
-                dir: path,
+                // enter the folder itself when the result is a directory,
+                // otherwise open the parent folder of the matched file
+                dir: item.type === 'dir' ? item.path : path,
               })
             }
           })


### PR DESCRIPTION
Fixes #520

### Problem

Search results are always navigated to the *parent* directory of the matched item. For files that is correct (you land in the folder that contains the file), but for folders the user expects to enter the matched folder itself — instead they land in its parent, which is exactly the folder they were trying to get out of.

### Cause

In `Search.vue`, every result is stored with `dir: path`, where `path` is the directory currently being scanned (i.e. the parent). `Browser.vue` then navigates with `goTo(item.dir)`, so folder results go to the parent.

### Fix

Use the directory's own path for folder results, and keep the parent path for files:

```js
dir: item.type === 'dir' ? item.path : path
```

One line; file behaviour is unchanged. (The adjacent recursive scan already relies on `subdir.path` for `type === 'dir'` items, so the field is the correct one to use.) Thanks to @MiiChielHD who pinpointed the same fix in the issue thread.

### Testing

Manual: Search → type a sub-folder name → click it. Before: opens the parent folder. After: opens the folder itself. File results still open the containing folder. Frontend-only change; the source is edited and `dist/` is left for the release build, matching prior PRs.

---
Disclosure: prepared with AI assistance (Claude) and reviewed by me before submitting.
