### PR TITLE
Match download_inline extensions case-insensitively

### DIFF
--- a/backend/Controllers/DownloadController.php
+++ b/backend/Controllers/DownloadController.php
@@ -66,7 +66,7 @@ class DownloadController
             // @codeCoverageIgnoreEnd
         });
 
-        $extension = pathinfo($file['filename'], PATHINFO_EXTENSION);
+        $extension = strtolower(pathinfo($file['filename'], PATHINFO_EXTENSION));
         $mimes = (new MimeTypes())->getMimeTypes($extension);
         $contentType = !empty($mimes) ? $mimes[0] : 'application/octet-stream';
 

--- a/tests/backend/Feature/FilesTest.php
+++ b/tests/backend/Feature/FilesTest.php
@@ -215,6 +215,25 @@ class FilesTest extends TestCase
         $this->assertOk();
     }
 
+    public function testDownloadUppercaseExtensionPDFFileHeadersInline()
+    {
+        $username = 'john@example.com';
+        $this->signIn($username, 'john123');
+
+        mkdir(TEST_REPOSITORY.'/john');
+        touch(TEST_REPOSITORY.'/john/JOHN.PDF', $this->timestamp);
+
+        $path_encoded = base64_encode('JOHN.PDF');
+        $this->sendRequest('GET', '/download&path='.$path_encoded);
+
+        $headers = $this->streamedResponse->headers;
+        // uppercase extension should still be previewed inline (download_inline => ['pdf'])
+        $this->assertEquals("inline; filename=file; filename*=utf-8''JOHN.PDF", $headers->get('content-disposition'));
+        $this->assertEquals('application/pdf', $headers->get('content-type'));
+
+        $this->assertOk();
+    }
+
     public function testDownloadUTF8File()
     {
         $username = 'john@example.com';


### PR DESCRIPTION
Files with an uppercase extension (e.g. `Invoice.PDF`, `photo.JPG` — common from scanners and cameras) are always sent as `attachment` and never previewed inline, even when the extension is listed in the `download_inline` config.

`DownloadController::download()` derives the extension via `pathinfo(..., PATHINFO_EXTENSION)`, which keeps the original case, then compares it against the (lowercase-documented) `download_inline` list — so `PDF` never matches `pdf`. Symfony's `MimeTypes` lookup is already case-insensitive, so the content-type was correct while only the disposition was wrong.

Fix: normalize the extension to lowercase before matching. One-line change, plus a Feature test covering an uppercase `.PDF` served inline.

Tested locally against PHPUnit (fail-before/pass-after; full `FilesTest` green — 25 tests). `dist/` left for the release build, matching prior PRs.
