### PR TITLE
Fix missing authorization in GET /batchdownload (GHSA-f74m-x83r-c4v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Upcoming...
+* Security fix: batch download archives are now bound to the session that created them, reported by Yulio Valdes (https://github.com/Yunnn-Yulio).
 * Fix unreadable .box text in dark theme, thanks @TowyTowy (see #589)
 * Add Danish translation (see #590)
 * Open the folder itself when selecting a folder search result (see #591 by @TowyTowy)

--- a/backend/Controllers/DownloadController.php
+++ b/backend/Controllers/DownloadController.php
@@ -24,6 +24,14 @@ use Symfony\Component\Mime\MimeTypes;
 
 class DownloadController
 {
+    // Session key holding the set of batch archive ids created by the current
+    // session. Used to authorize batch downloads (see batchDownloadStart).
+    const BATCH_ARCHIVES_SESSION_KEY = 'batch_download_archives';
+
+    // Upper bound on the ids kept in the session, so it cannot grow forever.
+    // Archives are normally downloaded right after being created.
+    const BATCH_ARCHIVES_LIMIT = 20;
+
     protected $auth;
 
     protected $session;
@@ -122,6 +130,10 @@ class DownloadController
 
         $uniqid = $archiver->createArchive($this->storage);
 
+        // Bind this archive to the current session so that later only its
+        // creator can download it. Must run before the session is saved below.
+        $this->rememberBatchArchive($uniqid);
+
         // close session
         $this->session->save();
 
@@ -139,9 +151,17 @@ class DownloadController
         return $response->json(['uniqid' => $uniqid]);
     }
 
-    public function batchDownloadStart(Request $request, StreamedResponse $streamedResponse, TmpfsInterface $tmpfs)
+    public function batchDownloadStart(Request $request, Response $response, StreamedResponse $streamedResponse, TmpfsInterface $tmpfs)
     {
         $uniqid = (string) preg_replace('/[^0-9a-zA-Z_]/', '', (string) $request->input('uniqid'));
+
+        // Authorization: only the session that created this archive may download
+        // it. Without this check any user who learns another user's archive id
+        // (e.g. from access logs) could retrieve their files. See GHSA-f74m-x83r-c4v4.
+        if (! $this->ownsBatchArchive($uniqid)) {
+            return $response->redirect('/');
+        }
+
         $file = $tmpfs->readStream($uniqid);
 
         $streamedResponse->setCallback(function () use ($file, $tmpfs, $uniqid) {
@@ -185,5 +205,29 @@ class DownloadController
         $this->session->save();
 
         $streamedResponse->send();
+    }
+
+    protected function rememberBatchArchive(string $uniqid)
+    {
+        $archives = (array) $this->session->get(self::BATCH_ARCHIVES_SESSION_KEY, []);
+
+        $archives[$uniqid] = true;
+
+        if (count($archives) > self::BATCH_ARCHIVES_LIMIT) {
+            $archives = array_slice($archives, -self::BATCH_ARCHIVES_LIMIT, null, true);
+        }
+
+        $this->session->set(self::BATCH_ARCHIVES_SESSION_KEY, $archives);
+    }
+
+    protected function ownsBatchArchive(string $uniqid): bool
+    {
+        if ($uniqid === '') {
+            return false;
+        }
+
+        $archives = (array) $this->session->get(self::BATCH_ARCHIVES_SESSION_KEY, []);
+
+        return isset($archives[$uniqid]);
     }
 }

--- a/backend/Services/Archiver/Adapters/ZipArchiver.php
+++ b/backend/Services/Archiver/Adapters/ZipArchiver.php
@@ -41,7 +41,10 @@ class ZipArchiver implements Service, ArchiverInterface
 
     public function createArchive(Storage $storage): string
     {
-        $this->uniqid = uniqid();
+        // Use a cryptographically secure, unguessable id instead of uniqid().
+        // uniqid() is timestamp-derived and predictable, which is unsafe for a
+        // token that gates access to a downloadable archive.
+        $this->uniqid = bin2hex(random_bytes(32));
 
         $this->archive = new Flysystem(
             new ZipAdapter($this->tmpfs->getFileLocation($this->uniqid))

--- a/tests/backend/Feature/BatchDownloadAuthorizationTest.php
+++ b/tests/backend/Feature/BatchDownloadAuthorizationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the FileGator package.
+ *
+ * (c) Milos Stojanovic <alcalbg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ */
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+/**
+ * Regression tests for GHSA-f74m-x83r-c4v4.
+ *
+ * GET /batchdownload used to stream a batch archive to anyone who supplied its
+ * id, without checking that the current session created it. These tests lock in
+ * the fix: a batch archive is bound to the session that created it and can only
+ * be downloaded by that session.
+ *
+ * @internal
+ */
+class BatchDownloadAuthorizationTest extends TestCase
+{
+    protected $timestamp;
+
+    protected function setUp(): void
+    {
+        $this->resetTempDir();
+
+        $this->timestamp = time();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetTempDir();
+    }
+
+    public function testCannotDownloadAnotherUsersBatchArchive()
+    {
+        // John (victim) creates a batch archive of a file inside his home dir.
+        $uniqid = $this->createSecretBatchArchiveAs('john@example.com', 'john123', '/john');
+
+        // Jack (attacker) is a separate regular user, with a different home dir
+        // and the read/download/batchdownload permissions the route requires, so
+        // the request reaches the controller instead of being stopped by the router.
+        $this->signIn('jack@example.com', 'jack123');
+
+        // Jack first creates an archive of his own, so his session is not empty.
+        // The check has to be per archive id, not merely "this session created
+        // some archive".
+        mkdir(TEST_REPOSITORY.'/jack');
+        file_put_contents(TEST_REPOSITORY.'/jack/jack.txt', 'jack');
+
+        $this->sendRequest('POST', '/batchdownload', [
+            'items' => [
+                [
+                    'type' => 'file',
+                    'path' => '/jack.txt',
+                    'name' => 'jack.txt',
+                    'time' => $this->timestamp,
+                ],
+            ],
+        ]);
+
+        $this->assertOk();
+
+        // Jack replays John's archive id.
+        $this->sendRequest('GET', '/batchdownload', [
+            'uniqid' => $uniqid,
+        ]);
+
+        // Before the fix this returned 200 with John's ZIP. Now the ownership
+        // check denies it: Jack is redirected to '/' and gets no archive.
+        $this->assertStatus(302);
+        $this->assertEquals('/', $this->response->headers->get('Location'));
+        $this->assertNotEquals(
+            'attachment; filename=archive.zip',
+            $this->streamedResponse->headers->get('content-disposition')
+        );
+
+        // The denied request must not consume or delete the victim's archive.
+        $this->assertFileExists(TEST_TMP_PATH.$uniqid);
+    }
+
+    public function testUnknownBatchArchiveIdIsDenied()
+    {
+        // A valid, fully-permissioned user cannot fish for archive ids they
+        // never created.
+        $this->signIn('john@example.com', 'john123');
+
+        $this->sendRequest('GET', '/batchdownload', [
+            'uniqid' => 'unknownbatcharchiveid0000000000000000000000000000',
+        ]);
+
+        $this->assertStatus(302);
+        $this->assertEquals('/', $this->response->headers->get('Location'));
+    }
+
+    // Declared last because the streamed download leaves the archive handle
+    // open, like the existing download tests in FilesTest do.
+    public function testOwnerCanDownloadOwnBatchArchive()
+    {
+        $uniqid = $this->createSecretBatchArchiveAs('john@example.com', 'john123', '/john');
+
+        // The same session that created the archive downloads it.
+        $this->sendRequest('GET', '/batchdownload', [
+            'uniqid' => $uniqid,
+        ]);
+
+        $this->assertOk();
+
+        $headers = $this->streamedResponse->headers;
+        $this->assertEquals('application/octet-stream', $headers->get('content-type'));
+        $this->assertEquals('attachment; filename=archive.zip', $headers->get('content-disposition'));
+    }
+
+    private function createSecretBatchArchiveAs(string $username, string $password, string $homedir): string
+    {
+        $this->signIn($username, $password);
+
+        mkdir(TEST_REPOSITORY.$homedir);
+        file_put_contents(TEST_REPOSITORY.$homedir.'/secret.txt', 'top secret');
+
+        $this->sendRequest('POST', '/batchdownload', [
+            'items' => [
+                [
+                    'type' => 'file',
+                    'path' => '/secret.txt',
+                    'name' => 'secret.txt',
+                    'time' => $this->timestamp,
+                ],
+            ],
+        ]);
+
+        $this->assertOk();
+
+        $res = json_decode($this->response->getContent());
+
+        return $res->data->uniqid;
+    }
+}

--- a/tests/backend/MockUsers.php
+++ b/tests/backend/MockUsers.php
@@ -70,10 +70,21 @@ class MockUsers extends JsonFile implements Service, AuthInterface
         $jane->setName('Jane Doe');
         $jane->setPermissions(['read', 'write']);
 
+        // A second regular user with its own home directory and the permissions
+        // required to reach the batch-download endpoints. Used to prove that one
+        // user cannot download another user's batch archive (GHSA-f74m-x83r-c4v4).
+        $jack = new User();
+        $jack->setRole('user');
+        $jack->setHomedir('/jack');
+        $jack->setUsername('jack@example.com');
+        $jack->setName('Jack Doe');
+        $jack->setPermissions(['read', 'write', 'download', 'batchdownload']);
+
         $this->add($guest, '');
         $this->add($admin, 'admin123');
         $this->add($john, 'john123');
         $this->add($jane, 'jane123');
+        $this->add($jack, 'jack123');
     }
 
 }


### PR DESCRIPTION
Reported privately as GHSA-f74m-x83r-c4v4 and coordinated by email with @alcalbg, who asked for a PR with the fix and tests. Opening this directly instead of filing a public issue first, since the report is a security one.

## Summary

`GET /batchdownload` streamed a batch archive to any permitted user who supplied its `uniqid` — the route requires `read`/`download`/`batchdownload`, but it never checked that the requester was the archive's owner.

In multi-user deployments with per-user home directories, a user who obtained another user's archive id could download that user's archive, crossing the home-directory boundary. The id travels in the download URL opened via `window.open`, so it reaches ordinary web-server access logs. A successful replay also deletes the victim's pending archive.

## Fix

- Bind each batch archive to the session that creates it, and verify ownership in `batchDownloadStart()` before streaming. Unknown or non-owned ids are redirected to `/`, matching how single-file `download()` denies access.
- Cap the number of ids kept in the session so it cannot grow without bound.
- Generate the archive id with `bin2hex(random_bytes(32))` instead of the predictable, timestamp-derived `uniqid()`. This is defense in depth — the ownership check is the actual control.

The legitimate flow is unaffected: the browser creates and downloads the archive within the same session, and no frontend change is needed.

## Tests

`tests/backend/Feature/BatchDownloadAuthorizationTest.php` covers:

- the owner can still download their own archive;
- a different user is denied — that user holds `read`/`download`/`batchdownload` so the router lets the request through to the controller, and creates an archive of their own first, so the check has to discriminate per id rather than merely "this session created something";
- an unknown id is denied.

This adds a second mock user with its own home directory. I verified the cross-user test fails (200 instead of 302) when the ownership check is removed, and that the rest of the suite behaves the same as on `master`.

I also added a line to the CHANGELOG under "Upcoming..." — happy to drop it if you would rather write that yourself.
