### PR TITLE
Fix missing authorization in POST /upload (GHSA-44r8-3p76-84mw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming...
 * Security fix: batch download archives are now bound to the session that created them, reported by Yulio Valdes (https://github.com/Yunnn-Yulio).
+* Security fix: uploads can no longer reach another user's temporary files via the chunk filename, reported by Yulio Valdes (https://github.com/Yunnn-Yulio).
 * Fix unreadable .box text in dark theme, thanks @TowyTowy (see #589)
 * Add Danish translation (see #590)
 * Open the folder itself when selecting a folder search result (see #591 by @TowyTowy)

--- a/backend/Controllers/UploadController.php
+++ b/backend/Controllers/UploadController.php
@@ -113,16 +113,26 @@ class UploadController
 
         // if all the chunks are present, create final file and store it
         if ($chunks_size >= $total_size) {
+            // Assemble the chunks into a temporary file kept inside this request's
+            // own namespace ($prefix already encodes the user), so the assembly can
+            // never read, write or delete another user's temporary files.
+            $assembled = $prefix.$file_name;
+
             for ($i = 1; $i <= $total_chunks; ++$i) {
                 $part = $this->tmpfs->readStream($prefix.$file_name.'.part'.$i);
-                $this->tmpfs->write($file_name, $part['stream'], true);
+                $this->tmpfs->write($assembled, $part['stream'], true);
             }
 
-            $final = $this->tmpfs->readStream($file_name);
-            $res = $this->storage->store($destination, $final['filename'], $final['stream'], $overwrite_on_upload);
+            $res = false;
+            if ($this->tmpfs->exists($assembled)) {
+                $final = $this->tmpfs->readStream($assembled);
+                // the stored name is the sanitized file name without the prefix
+                $name = substr($final['filename'], strlen($prefix));
+                $res = $this->storage->store($destination, $name, $final['stream'], $overwrite_on_upload);
+                $this->tmpfs->remove($assembled);
+            }
 
             // cleanup
-            $this->tmpfs->remove($file_name);
             foreach ($this->tmpfs->findAll($prefix.'*') as $expired_chunk) {
                 $this->tmpfs->remove($expired_chunk['name']);
             }

--- a/tests/backend/Feature/UploadAuthorizationTest.php
+++ b/tests/backend/Feature/UploadAuthorizationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the FileGator package.
+ *
+ * (c) Milos Stojanovic <alcalbg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ */
+
+namespace Tests\Feature;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\TestCase;
+
+/**
+ * Regression tests for GHSA-44r8-3p76-84mw.
+ *
+ * POST /upload used the request-supplied resumableFilename directly as a key
+ * into the shared temporary directory, so a user could read, store and delete
+ * any temporary file by name. These tests lock in the fix: the upload assembly
+ * only ever touches the request's own namespaced temporary files.
+ *
+ * @internal
+ */
+class UploadAuthorizationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetTempDir();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetTempDir();
+    }
+
+    public function testUploadCannotReachAnotherUsersTemporaryFile()
+    {
+        // A transient file that does not belong to the attacker, sitting in the
+        // shared temporary directory (e.g. another user's pending batch archive).
+        file_put_contents(TEST_TMP_PATH.'victimsecret', 'VICTIM SECRET');
+
+        // Attacker: a regular user holding the upload permission, with a home dir
+        // of their own.
+        $this->signIn('john@example.com', 'john123');
+        mkdir(TEST_REPOSITORY.'/john');
+
+        $fp = fopen(TEST_FILE, 'w');
+        fwrite($fp, 'x');
+        fclose($fp);
+        $files = ['file' => new UploadedFile(TEST_FILE, 'dummy.txt', 'text/plain', null, true)];
+
+        // The empty-assembly trick: resumableTotalChunks/Size = 0 skips the
+        // concatenation loop, so the pre-fix code assembled straight from the
+        // existing tmpfs file named by resumableFilename.
+        $this->sendRequest('POST', '/upload', [
+            'resumableChunkNumber' => 1,
+            'resumableTotalChunks' => 0,
+            'resumableTotalSize' => 0,
+            'resumableIdentifier' => 'ATTACK',
+            'resumableFilename' => 'victimsecret',
+            'resumableRelativePath' => '/',
+        ], $files);
+
+        // The victim's file must not have leaked into the attacker's home dir ...
+        $this->assertFileNotExists(TEST_REPOSITORY.'/john/victimsecret');
+        // ... and it must still be intact in the temporary directory.
+        $this->assertFileExists(TEST_TMP_PATH.'victimsecret');
+        $this->assertEquals('VICTIM SECRET', file_get_contents(TEST_TMP_PATH.'victimsecret'));
+    }
+
+    public function testNormalUploadStillWorks()
+    {
+        $this->signIn('john@example.com', 'john123');
+        mkdir(TEST_REPOSITORY.'/john');
+
+        $fp = fopen(TEST_FILE, 'w');
+        fwrite($fp, 'hello world');
+        fclose($fp);
+        $files = ['file' => new UploadedFile(TEST_FILE, 'sample.txt', 'text/plain', null, true)];
+
+        $this->sendRequest('POST', '/upload', [
+            'resumableChunkNumber' => 1,
+            'resumableChunkSize' => 1048576,
+            'resumableTotalChunks' => 1,
+            'resumableTotalSize' => 11,
+            'resumableIdentifier' => 'NORMAL',
+            'resumableFilename' => 'sample.txt',
+            'resumableRelativePath' => '/',
+        ], $files);
+
+        $this->assertOk();
+        $this->assertFileExists(TEST_REPOSITORY.'/john/sample.txt');
+        $this->assertEquals('hello world', file_get_contents(TEST_REPOSITORY.'/john/sample.txt'));
+    }
+}


### PR DESCRIPTION
Follow-up to #597, for the second advisory I filed privately: GHSA-44r8-3p76-84mw. You said I could send a PR for it — here it is.

## Summary

`POST /upload` used the request-supplied `resumableFilename` directly as a key into the shared temporary directory when assembling and storing the final file. A user with the `upload` permission could point the read/store/delete at any file in that directory by name — for example another user's pending batch archive — so the cross-user disclosure was still reproducible through this route even with #597 applied, and arbitrary temporary files could be deleted.

## Fix

- Assemble the chunks into a temporary file whose name is namespaced with the existing per-user `$prefix`, so the assembly can only ever touch the request's own temporary files.
- Derive the stored file name from the sanitized assembled name with the prefix stripped, so the existing filename sanitization is preserved (the bad-name test passes unchanged).
- Skip storing when no chunk was actually assembled — this closes the `resumableTotalChunks=0` / `resumableTotalSize=0` trick that made the assembly read a pre-existing file.

Normal uploads are unaffected.

## Tests

`tests/backend/Feature/UploadAuthorizationTest.php` covers a cross-user attempt (the target file is left intact and does not leak into the attacker's home dir) and a normal upload (still stored correctly). I confirmed the cross-user test fails against the pre-fix code, and the existing `UploadTest` still passes 6/6.
