### PR TITLE
Harden upload tmpfs namespace against username collisions + secure session cookie over HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Upcoming...
+* Hardening: the sample configuration now marks the session cookie Secure when the request is served over HTTPS.
 * Hardening: derive the per-user upload temporary namespace from a hash of the username, so accounts whose names differ only by stripped characters no longer share it.
 
 ## 7.15.1 - 2026-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Upcoming...
+* Hardening: derive the per-user upload temporary namespace from a hash of the username, so accounts whose names differ only by stripped characters no longer share it.
 
 ## 7.15.1 - 2026-08-13
 * LDAP security fix (https://github.com/filegator/filegator/security/advisories/GHSA-h3qf-hr78-8c64)

--- a/backend/Controllers/UploadController.php
+++ b/backend/Controllers/UploadController.php
@@ -44,7 +44,8 @@ class UploadController
         $file_name = $request->input('resumableFilename', 'file');
         $identifier = (string) preg_replace('/[^0-9a-zA-Z_]/', '', (string) $request->input('resumableIdentifier'));
         $username = $this->auth->user() ? $this->auth->user()->getUsername() : 'guest';
-        $clean_username = (string) preg_replace('/[^0-9a-zA-Z_]/', '', $username);
+        // same per-user namespace hash as upload() below
+        $clean_username = md5($username);
         $chunk_number = (int) $request->input('resumableChunkNumber');
 
         $chunk_file = 'multipart_'.$clean_username.'_'.$identifier.'_'.$file_name.'.part'.$chunk_number;
@@ -65,7 +66,11 @@ class UploadController
         $total_size = (int) $request->input('resumableTotalSize');
         $identifier = (string) preg_replace('/[^0-9a-zA-Z_]/', '', (string) $request->input('resumableIdentifier'));
         $username = $this->auth->user() ? $this->auth->user()->getUsername() : 'guest';
-        $clean_username = (string) preg_replace('/[^0-9a-zA-Z_]/', '', $username);
+        // hash the raw username so distinct users always get distinct tmpfs
+        // namespaces; sanitising with a character class collapses usernames that
+        // differ only by stripped characters (e.g. john.doe@x.com and
+        // johndoe@x.com both become johndoexcom) onto the same namespace
+        $clean_username = md5($username);
 
         $filebag = $request->files;
         $file = $filebag->get('file');

--- a/configuration_sample.php
+++ b/configuration_sample.php
@@ -48,9 +48,16 @@ return [
                     //$save_path = __DIR__.'/private/sessions';
                     $handler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler($save_path);
 
+                    // send the session cookie with the Secure flag when the
+                    // request is served over HTTPS, so it is never exposed over
+                    // plain HTTP; stays off for HTTP (e.g. local) so login keeps
+                    // working there. Behind a TLS-terminating proxy, set this to
+                    // true explicitly.
+                    $cookie_secure = ! empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off';
+
                     return new \Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage([
                             "cookie_samesite" => "Lax",
-                            "cookie_secure" => null,
+                            "cookie_secure" => $cookie_secure,
                             "cookie_httponly" => true,
                         ], $handler);
                 },

--- a/tests/backend/Feature/UploadNamespaceCollisionTest.php
+++ b/tests/backend/Feature/UploadNamespaceCollisionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the FileGator package.
+ *
+ * (c) Milos Stojanovic <alcalbg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ */
+
+namespace Tests\Feature;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Tests\TestCase;
+
+/**
+ * Hardening regression test for the upload tmpfs namespace (follow-up to
+ * GHSA-44r8-3p76-84mw).
+ *
+ * The per-user upload namespace was derived by stripping every character
+ * outside [0-9a-zA-Z_] from the username. Two distinct users whose usernames
+ * differ only by stripped characters (here bobsmith@example.com and
+ * bob.smith@example.com, both collapsing to "bobsmithexamplecom") therefore
+ * shared one namespace, re-opening the cross-user temporary-file access the
+ * advisory closed. Hashing the raw username keeps the namespaces distinct.
+ *
+ * @internal
+ */
+class UploadNamespaceCollisionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetTempDir();
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetTempDir();
+    }
+
+    public function testCollidingUsersDoNotShareTheUploadNamespace()
+    {
+        // A file the other Bob left in the namespace that a character-stripping
+        // sanitiser would assign to both accounts ("bobsmithexamplecom").
+        $shared = TEST_TMP_PATH.'multipart_bobsmithexamplecom_SHARED_secret.txt';
+        file_put_contents($shared, 'VICTIM SECRET');
+
+        // Attacker: the colliding sibling account, with its own home dir.
+        $this->signIn('bob.smith@example.com', 'bob2123');
+        mkdir(TEST_REPOSITORY.'/bob2');
+
+        $fp = fopen(TEST_FILE, 'w');
+        fwrite($fp, 'x');
+        fclose($fp);
+        $files = ['file' => new UploadedFile(TEST_FILE, 'dummy.txt', 'text/plain', null, true)];
+
+        // Empty-assembly trick: resumableTotalChunks/Size = 0 skips the concat
+        // loop, so the code assembles straight from an existing tmpfs file
+        // addressed by the attacker-supplied identifier + filename within the
+        // attacker's own namespace.
+        $this->sendRequest('POST', '/upload', [
+            'resumableChunkNumber' => 1,
+            'resumableTotalChunks' => 0,
+            'resumableTotalSize' => 0,
+            'resumableIdentifier' => 'SHARED',
+            'resumableFilename' => 'secret.txt',
+            'resumableRelativePath' => '/',
+        ], $files);
+
+        // The other Bob's file must not have leaked into the attacker's home ...
+        $this->assertFileNotExists(TEST_REPOSITORY.'/bob2/secret.txt');
+        // ... and must still be intact in the temporary directory.
+        $this->assertFileExists($shared);
+        $this->assertEquals('VICTIM SECRET', file_get_contents($shared));
+    }
+
+    public function testNormalUploadStillWorks()
+    {
+        $this->signIn('bobsmith@example.com', 'bob123');
+        mkdir(TEST_REPOSITORY.'/bob');
+
+        $fp = fopen(TEST_FILE, 'w');
+        fwrite($fp, 'hello world');
+        fclose($fp);
+        $files = ['file' => new UploadedFile(TEST_FILE, 'sample.txt', 'text/plain', null, true)];
+
+        $this->sendRequest('POST', '/upload', [
+            'resumableChunkNumber' => 1,
+            'resumableChunkSize' => 1048576,
+            'resumableTotalChunks' => 1,
+            'resumableTotalSize' => 11,
+            'resumableIdentifier' => 'NORMAL',
+            'resumableFilename' => 'sample.txt',
+            'resumableRelativePath' => '/',
+        ], $files);
+
+        $this->assertOk();
+        $this->assertFileExists(TEST_REPOSITORY.'/bob/sample.txt');
+        $this->assertEquals('hello world', file_get_contents(TEST_REPOSITORY.'/bob/sample.txt'));
+    }
+}

--- a/tests/backend/MockUsers.php
+++ b/tests/backend/MockUsers.php
@@ -80,11 +80,30 @@ class MockUsers extends JsonFile implements Service, AuthInterface
         $jack->setName('Jack Doe');
         $jack->setPermissions(['read', 'write', 'download', 'batchdownload']);
 
+        // Two distinct users whose usernames collapse to the same value under a
+        // [^0-9a-zA-Z_] sanitiser (both become "bobsmithexamplecom"), used to
+        // prove the upload tmpfs namespace stays isolated across such a pair.
+        $bob = new User();
+        $bob->setRole('user');
+        $bob->setHomedir('/bob');
+        $bob->setUsername('bobsmith@example.com');
+        $bob->setName('Bob Smith');
+        $bob->setPermissions(['read', 'write', 'upload', 'download']);
+
+        $bob2 = new User();
+        $bob2->setRole('user');
+        $bob2->setHomedir('/bob2');
+        $bob2->setUsername('bob.smith@example.com');
+        $bob2->setName('Bob Smith II');
+        $bob2->setPermissions(['read', 'write', 'upload', 'download']);
+
         $this->add($guest, '');
         $this->add($admin, 'admin123');
         $this->add($john, 'john123');
         $this->add($jane, 'jane123');
         $this->add($jack, 'jack123');
+        $this->add($bob, 'bob123');
+        $this->add($bob2, 'bob2123');
     }
 
 }


### PR DESCRIPTION
Two small hardening changes I mentioned earlier, kept separate from the LDAP session PR (#602). Same terms as #597 / #598.

## 1. Upload tmpfs namespace collision (hardens the GHSA-44r8 fix)

`UploadController` derives the per-user temporary namespace by stripping every character outside `[0-9a-zA-Z_]` from the username. Two distinct users whose usernames differ only by stripped characters collapse onto the same namespace, for example `bobsmith@example.com` and `bob.smith@example.com` both become `bobsmithexamplecom`. For such a pair, one user can reach the other's pending upload chunks and assembled file, which re-opens the cross-user temporary-file access GHSA-44r8-3p76-84mw closed.

Deriving the namespace from `md5()` of the raw username keeps distinct usernames in distinct, filesystem-safe namespaces. The value is only an internal tmpfs key (never shown or trusted), and both the chunk check and the assembly derive it identically.

`UploadNamespaceCollisionTest` proves a colliding sibling account cannot reach the other's file, plus a normal-upload guard. Mutation-checked to fail against the old sanitiser.

## 2. Secure session cookie over HTTPS (sample config)

`configuration_sample.php` set `cookie_secure` to `null`, so the session cookie was never marked `Secure`, even on HTTPS. It now follows the request scheme: on over HTTPS, off over plain HTTP so local/HTTP setups keep working. Proxy-terminated TLS can still set it to `true` explicitly.

## Note

Uploads in flight at the exact moment of deploy finish under a different namespace and would need re-uploading; a one-time transient, no data at risk. Happy to split the two commits if you'd prefer to take them separately.
