### PR TITLE
Fix silent failure when re-uploading identical files

### DIFF
--- a/frontend/views/partials/Upload.vue
+++ b/frontend/views/partials/Upload.vue
@@ -122,6 +122,22 @@ export default {
   mounted() {
     this.resumable = new Resumable({
       target: Vue.config.baseURL+'/upload',
+      generateUniqueIdentifier: (file, event) => {
+        let relativePath = file.webkitRelativePath||file.relativePath||file.fileName||file.name;
+        let size = file.size;
+        let uniqueIdentifier = size + '-' + relativePath.replace(/[^0-9a-zA-Z_-]/img, '');
+
+        if (this.resumable && typeof this.resumable.getFromUniqueIdentifier === 'function') {
+          let existing = this.resumable.getFromUniqueIdentifier(uniqueIdentifier);
+          if (existing) {
+            let entry = this.findEntry(existing);
+            if (!entry || entry.isComplete || entry.isError) {
+              uniqueIdentifier += '-' + Date.now();
+            }
+          }
+        }
+        return uniqueIdentifier;
+      },
       headers: {
         'x-csrf-token': axios.defaults.headers.common['x-csrf-token']
       },


### PR DESCRIPTION
# Description
Fixes a bug where attempting to drag-and-drop a file that was previously uploaded would silently fail without initiating the upload or logging any console errors. Closes https://github.com/hestiacp/hestiacp/issues/5701.

### Root Cause
File uploads are handled by `Resumable.js`, which generates a unique identifier for each file based on its name and size to prevent duplicate uploads. When an upload successfully completes (or errors out), it remains in Resumable's internal queue unless the user explicitly closes the upload progress window. If the exact same file is dragged into the dropzone again, Resumable.js finds the existing unique identifier in its queue and silently ignores the drop.

### Solution
Provided a custom `generateUniqueIdentifier` configuration to Resumable.js in `Upload.vue`. 

When a file is dropped, the system now checks if the generated identifier already exists in the queue. If it does, and its corresponding entry is marked as either `completed` or `errored`, a timestamp is appended to the identifier. This forces Resumable.js to treat it as a brand-new file, allowing the upload to proceed normally without breaking the ability to resume paused/crashed uploads.

### Steps to Reproduce the Bug (Before Fix)
1. Navigate to a folder in the File Manager.
2. Upload a file (e.g., `example.txt`) via drag-and-drop.
3. Drag-and-drop the exact same file (`example.txt`) into the same folder again (it uploads as `example (1).txt`).
4. Delete both `example.txt` and `example (1).txt` using the file manager UI.
5. Attempt to drag-and-drop the original `example.txt` file into the folder one more time.

**Expected:** The file should upload normally as `example.txt`.
**Actual:** Nothing happens. The upload does not initiate, there is no success/failure prompt, and the console remains clear.