### PR TITLE
Fix editor undo history clearing file contents and handle load errors

### DIFF
--- a/frontend/views/partials/Editor.vue
+++ b/frontend/views/partials/Editor.vue
@@ -7,7 +7,7 @@
         </p>
       </header>
       <section class="modal-card-body preview">
-        <template>
+        <template v-if="loaded">
           <prism-editor v-model="content" language="md" :readonly="!can('write')" :line-numbers="lineNumbers" />
         </template>
       </section>
@@ -39,6 +39,7 @@ export default {
       content: '',
       currentItem: '',
       lineNumbers: true,
+      loaded: false,
     }
   },
   mounted() {
@@ -48,8 +49,12 @@ export default {
     })
       .then((res) => {
         this.content = res
+        this.loaded = true
       })
-      .catch(error => this.handleError(error))
+      .catch(error => {
+        this.handleError(error)
+        this.$parent.close()
+      })
   },
   methods: {
     saveFile() {


### PR DESCRIPTION
## Description
This PR resolves an issue where repeatedly pressing `Ctrl+Z` in the built-in text editor would eventually clear the entire file. It also improves error handling when a file fails to load. Closes https://github.com/hestiacp/hestiacp/issues/5705.

## Root Cause
The `vue-prism-editor` tracks its own undo history. Previously, the editor was rendered immediately with an empty string state before the file's contents were fetched from the API. When the API response successfully loaded the file text, the editor registered this update as the initial user "edit". Undoing past actual manual edits would therefore undo the file load itself, presenting an empty file. 

Furthermore, if the API request failed (e.g., due to permissions), the error was caught and displayed via a toast, but the modal was not closed, leaving the user staring at a falsely empty file.

## Changes Made
- Added a `loaded` boolean to the `Editor.vue` state.
- Wrapped the `<prism-editor>` component in a `<template v-if="loaded">` directive so it is only mounted and initialized *after* the file contents are successfully downloaded. This correctly sets the undo stack's base state to the loaded file.
- Appended `this.$parent.close()` to the API `.catch()` block. Now, if there is a file permission issue or the file is inaccessible, the error toast is displayed and the modal gracefully closes rather than presenting an empty text editor.